### PR TITLE
Fix 3x API KEYCLOAK_URLs

### DIFF
--- a/.github/workflows/merge-demo.yml
+++ b/.github/workflows/merge-demo.yml
@@ -211,6 +211,7 @@ jobs:
             -p PROMOTE=${{ github.repository }}:${{ env.ZONE }}-db | oc apply -f -
           oc process -f .github/openshift/deploy.api.yml -p ZONE=${{ env.ZONE }} \
             -p PROMOTE=${{ github.repository }}:${{ env.ZONE }}-api -p DB_TESTDATA=true \
+            -p KEYCLOAK_URL="https://test.oidc.gov.bc.ca/auth" -p DB_TESTDATA=false \
             -p NAMESPACE=${{ secrets.NAMESPACE }} \
             | oc apply -f -
           oc process -f .github/openshift/deploy.admin.yml -p ZONE=${{ env.ZONE }} \

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -217,6 +217,7 @@ jobs:
             -p PROMOTE=${{ github.repository }}:${{ env.ZONE }}-db | oc apply -f -
           oc process -f .github/openshift/deploy.api.yml -p ZONE=${{ env.ZONE }} \
             -p PROMOTE=${{ github.repository }}:${{ env.ZONE }}-api -p DB_TESTDATA=true \
+            -p KEYCLOAK_URL="https://test.oidc.gov.bc.ca/auth" -p DB_TESTDATA=false \
             -p NAMESPACE=${{ secrets.NAMESPACE }} \
             | oc apply -f -
           oc process -f .github/openshift/deploy.admin.yml -p ZONE=${{ env.ZONE }} \
@@ -321,6 +322,7 @@ jobs:
             -p PROMOTE=${{ github.repository }}:${{ env.PREV }}-db | oc apply -f -
           oc process -f .github/openshift/deploy.api.yml -p ZONE=${{ env.ZONE }} \
             -p PROMOTE=${{ github.repository }}:${{ env.PREV }}-api \
+            -p KEYCLOAK_URL="https://prod.oidc.gov.bc.ca/auth" -p DB_TESTDATA=false \
             -p NAMESPACE=${{ secrets.NAMESPACE }} \
             | oc apply -f -
           oc process -f .github/openshift/deploy.admin.yml -p ZONE=${{ env.ZONE }} \

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -395,11 +395,11 @@ jobs:
   sonarcloud:
     name: Static Analysis
     needs:
-      - tests-api
       - build-db
       - build-api
       - build-admin
       - build-public
+      - tests-api
     if:
       always() && (needs.build-db.result == 'success' || needs.build-api.result == 'success' ||
       needs.build-admin.result == 'success' || needs.build-public.result == 'success')

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -404,6 +404,8 @@ jobs:
       always() && (needs.build-db.result == 'success' || needs.build-api.result == 'success' ||
       needs.build-admin.result == 'success' || needs.build-public.result == 'success')
     runs-on: ubuntu-latest
+    environment:
+      name: dev
     steps:
       - uses: actions/checkout@v2
         # Disable shallow clone for SonarCloud analysis


### PR DESCRIPTION
Bug: recent deployments have dropped tye KEYCLOACK_URL params from deployment.  Thankfully we're still running in parallel to old FOM.