### PR TITLE
Remove path from API's HOSTNAME var

### DIFF
--- a/.github/openshift/deploy.api.yml
+++ b/.github/openshift/deploy.api.yml
@@ -152,7 +152,7 @@ objects:
                 - name: ENV
                   value: ${ZONE}
                 - name: HOSTNAME
-                  value: ${URL}/${COMPONENT}
+                  value: ${URL}
                 - name: PORT
                   value: "${PORT}"
                 - name: KEYCLOAK_ENABLED


### PR DESCRIPTION
This was throwing off the links in the new FOM notification email.