### PR TITLE
Update emails for finalized FOMs

### DIFF
--- a/.github/openshift/deploy.api.yml
+++ b/.github/openshift/deploy.api.yml
@@ -28,21 +28,19 @@ parameters:
   - name: DB_TESTDATA
     description: Whether to load test data
     value: "false"
-  - description: SMTP Server URL for sending emails
-    displayName: SMTP Server URL
-    name: SMTP_SERVER
+  - name: FOM_EMAIL_NOTIFY
+    description: Email address to notify when a FOM closes
+  - name: SMTP_SERVER
+    description: SMTP Server URL for sending emails
     value: "smtp://apps.smtp.gov.bc.ca/?port=25&ignoreTLS=true&secure=false"
-  - description: URL of Keycloak Server to use for authentication.
-    displayName: Keycloak Server URL
-    name: KEYCLOAK_URL
+  - name: KEYCLOAK_URL
+    description: URL of Keycloak Server to use for authentication.
     value: "https://oidc.gov.bc.ca/auth"
-  - description: URL of SiteMinder Server used for logout (with BCeID)
-    displayName: SiteMinder Server URL
-    name: SITEMINDER_URL
+  - name: SITEMINDER_URL
+    description: URL of SiteMinder Server used for logout (with BCeID)
     value: "https://logon7.gov.bc.ca"
-  - description: URL of Object Storage Service
-    displayName: Object Storage URL
-    name: OBJECT_STORAGE_URL
+  - name: OBJECT_STORAGE_URL
+    description: URL of Object Storage Service
     value: "nrs.objectstore.gov.bc.ca"
   - name: URL
     description: Deployment URL, e.g. fom-123.apps.silver.devops.gov.bc.ca or fom.nrs.gov.bc.ca
@@ -64,9 +62,8 @@ parameters:
     description: Random number, 0-60, for scheduling cronjobs
     from: "[0-5]{1}[0-9]{1}"
     generate: expression
-  - description: Number of replicas
-    displayName: Replica Count
-    name: REPLICA_COUNT
+  - name: REPLICA_COUNT
+    description: Number of replicas
     required: false
     value: "3"
 objects:
@@ -149,8 +146,8 @@ objects:
                     secretKeyRef:
                       key: database-user
                       name: ${NAME}-${ZONE}-db
-                - name: ENV
-                  value: ${ZONE}
+                - name: FOM_EMAIL_NOTIFY
+                  value: ${FOM_EMAIL_NOTIFY}
                 - name: HOSTNAME
                   value: ${URL}
                 - name: PORT

--- a/.github/workflows/merge-demo.yml
+++ b/.github/workflows/merge-demo.yml
@@ -224,6 +224,7 @@ jobs:
             -p PROMOTE=${{ github.repository }}:${{ env.ZONE }}-db | oc apply -f -
 
           oc process -f .github/openshift/deploy.api.yml -p ZONE=${{ env.ZONE }} -p PROMOTE=${{ env.IMG }}-api \
+            -p FOM_EMAIL_NOTIFY=FLNR.AdminServicesCariboo@gov.bc.ca \
             -p URL=${{ env.URL }} -p CERTBOT=false -p REPLICA_COUNT=3 \
             -p NAMESPACE=${{ secrets.OC_NAMESPACE }} -p DB_TESTDATA=true \
             -p SITEMINDER_URL="https://logontest7.gov.bc.ca" -p KEYCLOAK_URL="https://test.oidc.gov.bc.ca/auth" \

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -251,6 +251,7 @@ jobs:
             | oc apply -f -
 
           oc process -f .github/openshift/deploy.api.yml -p ZONE=${{ env.ZONE }} -p PROMOTE=${{ env.IMG }}-api \
+            -p FOM_EMAIL_NOTIFY=FLNR.AdminServicesCariboo@gov.bc.ca \
             -p URL=${{ env.URL }} -p CERTBOT=true -p REPLICA_COUNT=3 \
             -p NAMESPACE=${{ secrets.OC_NAMESPACE }} -p DB_TESTDATA=true \
             -p SITEMINDER_URL="https://logontest7.gov.bc.ca" -p KEYCLOAK_URL="https://test.oidc.gov.bc.ca/auth" \

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -521,6 +521,7 @@ jobs:
             echo "Database already deployed"
 
           oc process -f .github/openshift/deploy.api.yml -p ZONE=${{ env.ZONE }} -p PROMOTE=${{ env.IMG }}-api \
+            -p FOM_EMAIL_NOTIFY=SIBIFSAF@victoria1.gov.bc.ca \
             -p URL=${{ env.URL }} -p CERTBOT=false -p REPLICA_COUNT=1 \
             -p NAMESPACE=${{ secrets.OC_NAMESPACE }} -p DB_TESTDATA=true \
             -p SITEMINDER_URL="https://logontest7.gov.bc.ca" -p KEYCLOAK_URL="https://dev.oidc.gov.bc.ca/auth" \

--- a/api/src/core/mail/mail.service.ts
+++ b/api/src/core/mail/mail.service.ts
@@ -8,22 +8,26 @@ export class MailService {
   constructor(private mailerService: MailerService, private logger: PinoLogger) {}
 
   async sendDistrictNotification(project: Project) {
-    const env = process.env.ENV || 'dev';
-    const isProd = (env == 'prod');
-    const isTest = (env == 'test');
+
+    // Email address used for PROD, populated from the Db
     const districtEmail = project.district.email + "@gov.bc.ca"; // production - table stores emails without the @gov.bc.ca suffix.
-    const testEnvTo = 'FLNR.AdminServicesCariboo@gov.bc.ca'; // test
+
+    // Use ${districtEmail} in PROD, otherwise provided in var for lower environments (DEV, TEST, DEMO)
+    const to = process.env.FOM_EMAIL_NOTIFY ? `${process.env.FOM_EMAIL_NOTIFY}` : `${districtEmail}`
+
+    // Link to FOM
     const host = process.env.HOSTNAME? `https://${process.env.HOSTNAME}`: 'http://localhost:4200';
     const fomViewLink = `${host}/admin/a/${project.id}`;
 
-    const to = isProd? districtEmail: (isTest? testEnvTo: 'basil.vandegriend@cgi.com');
+    // From email address
     const from = '"FOMDoNotReply" <Do-Not-Reply@gov.bc.ca'; // override default from;
-    const prodRecipientMsg = isProd? '' : ` Production recipient = ${districtEmail}`;
-    this.logger.info(`Sending FOM ${project.id} finalized notification email to ${to}${prodRecipientMsg}`);
+
+    // Log and send email
+    this.logger.info(`Sending FOM ${project.id} finalized notification email to ${to}`);
     await this.mailerService.sendMail({
       to: to,
       from: from,
-      subject: `<${env}> New Final FOM submission received`,
+      subject: `New Final FOM submission received for ${host}/admin/`,
       html: `<h3>FOM ${project.id} ${project.name} ${project.forestClient.name} has been finalized and is available for review.</h3>
         <p>
           Please use this <a href="${fomViewLink}" target="_blank">link</a> to access FOM details.


### PR DESCRIPTION
Email addresses provided by pipeline workflows.  Omitted for PROD, which pulls up its own address from the database.

FUNCTIONALITY CHANGE: Mail service's process.env.ENV var has been dropped.  There is no longer any concept of environment (DEV, TEST, DEMO, PROD), but will instead show hostname/admin in the email subject.