### PR TITLE
Online public notice - show 'disclaimer' after each notice

### DIFF
--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.html
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.html
@@ -81,7 +81,7 @@
         </mat-accordion>
       </section>
       <div class="validity-txt" *ngIf="pNotices.length > 0">
-        These FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road permit application, or the issuance of a Timber Sales License until the date three years after commencement of the public review and commenting period.
+        This FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road permit application, or the issuance of a Timber Sales License until the date three years after commencement of the public review and commenting period.
       </div>
     </div>
 

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.html
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.html
@@ -80,9 +80,6 @@
           </div>
         </mat-accordion>
       </section>
-      <div class="validity-txt" *ngIf="pNotices.length > 0">
-        This FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road permit application, or the issuance of a Timber Sales License until the date three years after commencement of the public review and commenting period.
-      </div>
     </div>
 
     <ng-template #no_notice_message >

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.html
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.html
@@ -167,6 +167,15 @@
         <div class="col-sm-4 bold">Email for Public Comment: </div>
         <div class="col-sm-8">{{pn.email}}</div>
       </div>
+
+      <div class="validity-txt">
+        <p>
+          This FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road
+          permit application, or the issuance of a Timber Sales License until the date three years
+          after commencement of the public review and commenting period.
+        </p>
+      </div>
+
     </ng-template>
   </div>
 

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.html
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.html
@@ -169,11 +169,11 @@
       </div>
 
       <div class="validity-txt">
-        <p>
+        <div style="margin-bottom: 15px;">
           This FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road
           permit application, or the issuance of a Timber Sales License until the date three years
           after commencement of the public review and commenting period.
-        </p>
+        </div>
       </div>
 
     </ng-template>


### PR DESCRIPTION
For the public site list of public notices, show the 'disclaimer' text after each notice and reword to "This FOM...".

Disclaimer text currently is: "These FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road permit application, or the issuance of a Timber Sales License until the date three years after commencement of the public review and commenting period."