### PR TITLE
Public Notice Operation Year Api Change

### DIFF
--- a/api/openapi/swagger-spec.json
+++ b/api/openapi/swagger-spec.json
@@ -445,6 +445,12 @@
           "email": {
             "type": "string"
           },
+          "operationStartYear": {
+            "type": "number"
+          },
+          "operationEndYear": {
+            "type": "number"
+          },
           "project": {
             "$ref": "#/components/schemas/ProjectResponse"
           }
@@ -458,6 +464,8 @@
           "isReceiveCommentsSameAsReview",
           "mailingAddress",
           "email",
+          "operationStartYear",
+          "operationEndYear",
           "project"
         ]
       },
@@ -488,6 +496,12 @@
           "email": {
             "type": "string"
           },
+          "operationStartYear": {
+            "type": "number"
+          },
+          "operationEndYear": {
+            "type": "number"
+          },
           "revisionCount": {
             "type": "number"
           },
@@ -504,6 +518,8 @@
           "isReceiveCommentsSameAsReview",
           "mailingAddress",
           "email",
+          "operationStartYear",
+          "operationEndYear",
           "revisionCount",
           "id"
         ]
@@ -534,6 +550,12 @@
           },
           "email": {
             "type": "string"
+          },
+          "operationStartYear": {
+            "type": "number"
+          },
+          "operationEndYear": {
+            "type": "number"
           }
         },
         "required": [
@@ -544,7 +566,9 @@
           "receiveCommentsBusinessHours",
           "isReceiveCommentsSameAsReview",
           "mailingAddress",
-          "email"
+          "email",
+          "operationStartYear",
+          "operationEndYear"
         ]
       },
       "PublicNoticeUpdateRequest": {
@@ -574,6 +598,12 @@
           "email": {
             "type": "string"
           },
+          "operationStartYear": {
+            "type": "number"
+          },
+          "operationEndYear": {
+            "type": "number"
+          },
           "revisionCount": {
             "type": "number"
           }
@@ -587,6 +617,8 @@
           "isReceiveCommentsSameAsReview",
           "mailingAddress",
           "email",
+          "operationStartYear",
+          "operationEndYear",
           "revisionCount"
         ]
       },

--- a/api/src/app/modules/project/public-notice.dto.ts
+++ b/api/src/app/modules/project/public-notice.dto.ts
@@ -38,6 +38,13 @@ export class PublicNoticeCreateRequest {
   @MaxLength(100) 
   email: string;
   
+  @ApiProperty({ required: true })
+  @IsNumber()
+  operationStartYear: number;
+
+  @ApiProperty({ required: true })
+  @IsNumber()
+  operationEndYear: number;
 }
 
 export class PublicNoticeUpdateRequest extends PublicNoticeCreateRequest {

--- a/api/src/app/modules/project/public-notice.entity.ts
+++ b/api/src/app/modules/project/public-notice.entity.ts
@@ -39,4 +39,9 @@ export class PublicNotice extends ApiBaseEntity<PublicNotice> {
   @Column()
   email: string
 
+  @Column({ name: 'operation_start_year'})
+  operationStartYear: number;
+
+  @Column({ name: 'operation_end_year'})
+  operationEndYear: number;
 }

--- a/api/src/app/modules/project/public-notice.service.ts
+++ b/api/src/app/modules/project/public-notice.service.ts
@@ -173,6 +173,8 @@ export class PublicNoticeService extends DataService<PublicNotice, Repository<Pu
     response.mailingAddress = entity.mailingAddress;
     response.email = entity.email;
     response.revisionCount = entity.revisionCount;
+    response.operationStartYear = entity.operationStartYear;
+    response.operationEndYear = entity.operationEndYear;
     return response;
   }
 

--- a/api/src/migrations/main/1661461702043-public-notice-addColumn-operationYears.js
+++ b/api/src/migrations/main/1661461702043-public-notice-addColumn-operationYears.js
@@ -1,0 +1,38 @@
+const { MigrationInterface, QueryRunner } = require("typeorm");
+
+module.exports = class publicNoticeAddColumnOperationYears1661461702043 {
+
+  async up(queryRunner) {
+    console.log('Starting public_notice (add new columns - operation_start_year, operation_end_year) migration');
+    await queryRunner.query(`
+
+    -- add new column - operation_start_year, nullable (for existing data before new column exists)
+      ALTER TABLE app_fom.public_notice ADD COLUMN operation_start_year integer;
+
+    -- add new column - operation_end_year, nullable (for existing data before new column exists)
+	    ALTER TABLE app_fom.public_notice ADD COLUMN operation_end_year integer;
+
+    -- comment on column - operation_start_year
+      COMMENT ON COLUMN app_fom.public_notice.operation_start_year IS
+        'Starting Year of planned duration of the FOM operations';
+      
+    -- comment on column - operation_end_year
+      COMMENT ON COLUMN app_fom.public_notice.operation_end_year IS
+        'Ending Year of planned duration of the FOM operations';
+
+    `);
+  }
+
+  async down(queryRunner) {
+    console.log('Starting public_notice (drop columns - operation_start_year, operation_end_year) migration');
+    await queryRunner.query(`
+
+    -- drop new columns - operation_start_year, operation_end_year
+        ALTER TABLE app_fom.public_notice DROP COLUMN operation_start_year;
+        ALTER TABLE app_fom.public_notice DROP COLUMN operation_end_year;
+
+    `);
+
+  }
+}
+        

--- a/libs/client/typescript-ng/.openapi-generator/FILES
+++ b/libs/client/typescript-ng/.openapi-generator/FILES
@@ -1,4 +1,5 @@
 .gitignore
+.openapi-generator-ignore
 README.md
 api.module.ts
 api/api.ts

--- a/libs/client/typescript-ng/model/publicNoticeCreateRequest.ts
+++ b/libs/client/typescript-ng/model/publicNoticeCreateRequest.ts
@@ -20,5 +20,7 @@ export interface PublicNoticeCreateRequest {
     isReceiveCommentsSameAsReview: boolean;
     mailingAddress: string;
     email: string;
+    operationStartYear: number;
+    operationEndYear: number;
 }
 

--- a/libs/client/typescript-ng/model/publicNoticePublicFrontEndResponse.ts
+++ b/libs/client/typescript-ng/model/publicNoticePublicFrontEndResponse.ts
@@ -21,6 +21,8 @@ export interface PublicNoticePublicFrontEndResponse {
     isReceiveCommentsSameAsReview: boolean;
     mailingAddress: string;
     email: string;
+    operationStartYear: number;
+    operationEndYear: number;
     project: ProjectResponse;
 }
 

--- a/libs/client/typescript-ng/model/publicNoticeResponse.ts
+++ b/libs/client/typescript-ng/model/publicNoticeResponse.ts
@@ -20,6 +20,8 @@ export interface PublicNoticeResponse {
     isReceiveCommentsSameAsReview: boolean;
     mailingAddress: string;
     email: string;
+    operationStartYear: number;
+    operationEndYear: number;
     revisionCount: number;
     id: number;
 }

--- a/libs/client/typescript-ng/model/publicNoticeUpdateRequest.ts
+++ b/libs/client/typescript-ng/model/publicNoticeUpdateRequest.ts
@@ -20,6 +20,8 @@ export interface PublicNoticeUpdateRequest {
     isReceiveCommentsSameAsReview: boolean;
     mailingAddress: string;
     email: string;
+    operationStartYear: number;
+    operationEndYear: number;
     revisionCount: number;
 }
 


### PR DESCRIPTION
- This change is related to task: https://app.zenhub.com/workspaces/fsa-fingerprint-61f04f08304d3e001a4f2578/issues/bcgov/nr-fom/222
- Migration script for public_notice (add new columns - operation_start_year, operation_end_year)
- Add fields (operationStartYear, operationEndYear) to entity and dto classes.
- Add custom IsNotLessThan validation decorator for endpoint validation and message.