### PR TITLE
Public notice operation year based timeline

### DIFF
--- a/admin/src/app/foms/public-notice/public-notice-edit.component.html
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.html
@@ -148,7 +148,7 @@
 
       <div class="form-row" >
         <div class="form-group col-md-12">
-          <label for="op-start-year" [ngClass]="{'required': editMode}">Operation Start Year</label>
+          <label for="op-start-year" [ngClass]="{'required': editMode}">Proposed Start of Operations</label>
           <input
             id="op-start-year"
             name="op-start-year"
@@ -171,7 +171,7 @@
 
       <div class="form-row" >
         <div class="form-group col-md-12">
-          <label for="op-end-year" [ngClass]="{'required': editMode}">Operation End Year</label>
+          <label for="op-end-year" [ngClass]="{'required': editMode}">Proposed End of Operations</label>
           <input
             id="op-end-year"
             name="op-end-year"

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.html
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.html
@@ -189,6 +189,11 @@
               && getErrorMessage('opEndDate', 'required')">
               {{getErrorMessage('opEndDate', 'required')}}
           </div>
+          <div class="invalid-feedback" 
+            *ngIf="(form.submitted || fieldTouchedOrDirty('opEndDate')) 
+              && getErrorMessage('opEndDate', 'minDate')">
+              {{getErrorMessage('opEndDate', 'minDate')}}
+          </div>
         </div>
       </div>
 

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.html
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.html
@@ -148,6 +148,52 @@
 
       <div class="form-row" >
         <div class="form-group col-md-12">
+          <label for="op-start-year" [ngClass]="{'required': editMode}">Operation Start Year</label>
+          <input
+            id="op-start-year"
+            name="op-start-year"
+            style="width: 10rem;"
+            class="form-control"
+            type="text"
+            placeholder="YYYY"
+            formControlName="opStartDate"
+            bsDatepicker
+            onkeydown="return false"
+            [bsConfig]="bsConfig"
+          />
+          <div class="invalid-feedback" 
+            *ngIf="(form.submitted || fieldTouchedOrDirty('opStartDate')) 
+              && getErrorMessage('opStartDate', 'required')">
+              {{getErrorMessage('opStartDate', 'required')}}
+          </div>
+        </div>
+      </div>
+
+      <div class="form-row" >
+        <div class="form-group col-md-12">
+          <label for="op-end-year" [ngClass]="{'required': editMode}">Operation End Year</label>
+          <input
+            id="op-end-year"
+            name="op-end-year"
+            style="width: 10rem;"
+            class="form-control"
+            type="text"
+            placeholder="YYYY"
+            formControlName="opEndDate"
+            bsDatepicker
+            onkeydown="return false"
+            [bsConfig]="bsConfig"
+          />
+          <div class="invalid-feedback" 
+            *ngIf="(form.submitted || fieldTouchedOrDirty('opEndDate')) 
+              && getErrorMessage('opEndDate', 'required')">
+              {{getErrorMessage('opEndDate', 'required')}}
+          </div>
+        </div>
+      </div>
+
+      <div class="form-row" >
+        <div class="form-group col-md-12">
           <label for="mailing-address" [ngClass]="{'required': editMode}">Mailing Address</label>
           <textarea class="form-control mb" rows="3" 
             id="mailing-address" name="mailing-address"

--- a/admin/src/app/foms/public-notice/public-notice.form.ts
+++ b/admin/src/app/foms/public-notice/public-notice.form.ts
@@ -1,3 +1,4 @@
+import { PublicNoticeResponse } from "@api-client";
 import { email, notEmpty, prop, required } from "@rxweb/reactive-form-validators";
 import * as R from 'remeda';
 export class PublicNoticeForm {
@@ -52,12 +53,22 @@ export class PublicNoticeForm {
   @prop()
   email: string;
 
-  constructor(publicNoticeResponse?: any) {
+  // Special case. It is at form control, but will be convert into request body for 'operationStartYear' (number).
+  @required({message: 'Operation Start Year is required.'})
+  @prop()
+  opStartDate: Date;
+
+  // Special case. It is at form control, but will be convert into request body for 'operationEndYear' (number).
+  @required({message: 'Operation End Year is required.'})
+  @prop()
+  opEndDate: Date;
+
+  constructor(publicNoticeResponse?: PublicNoticeResponse) {
     if (publicNoticeResponse) {
       // Pick the field to instantiate.
       Object.assign(this, R.pick(publicNoticeResponse, 
         [
-          'project.projectId',
+          'projectId',
           'id',
           'reviewAddress',
           'reviewBusinessHours',

--- a/admin/src/app/foms/public-notice/public-notice.form.ts
+++ b/admin/src/app/foms/public-notice/public-notice.form.ts
@@ -1,5 +1,5 @@
 import { PublicNoticeResponse } from "@api-client";
-import { email, notEmpty, prop, required } from "@rxweb/reactive-form-validators";
+import { email, minDate, notEmpty, prop, required } from "@rxweb/reactive-form-validators";
 import * as R from 'remeda';
 export class PublicNoticeForm {
 
@@ -60,6 +60,7 @@ export class PublicNoticeForm {
 
   // Special case. It is at form control, but will be convert into request body for 'operationEndYear' (number).
   @required({message: 'Operation End Year is required.'})
+  @minDate({fieldName:'opStartDate', message: 'Must be the same or after Operation Start Year'})
   @prop()
   opEndDate: Date;
 

--- a/admin/src/app/foms/public-notice/public-notice.form.ts
+++ b/admin/src/app/foms/public-notice/public-notice.form.ts
@@ -1,5 +1,6 @@
 import { PublicNoticeResponse } from "@api-client";
 import { email, minDate, notEmpty, prop, required } from "@rxweb/reactive-form-validators";
+import moment = require("moment");
 import * as R from 'remeda';
 export class PublicNoticeForm {
 
@@ -60,14 +61,15 @@ export class PublicNoticeForm {
 
   // Special case. It is at form control, but will be convert into request body for 'operationEndYear' (number).
   @required({message: 'Operation End Year is required.'})
-  @minDate({fieldName:'opStartDate', message: 'Must be the same or after Operation Start Year'})
+  @minDate({fieldName:'opStartDate', message: 'Must be the same or after Proposed Start of Operations'})
   @prop()
   opEndDate: Date;
 
   constructor(publicNoticeResponse?: PublicNoticeResponse) {
-    if (publicNoticeResponse) {
+    const pn = publicNoticeResponse;
+    if (pn) {
       // Pick the field to instantiate.
-      Object.assign(this, R.pick(publicNoticeResponse, 
+      Object.assign(this, R.pick(pn, 
         [
           'projectId',
           'id',
@@ -80,6 +82,28 @@ export class PublicNoticeForm {
           'email'
         ]
       ));
+    }
+
+    this.initProposedOperations(pn);
+  }
+
+  initProposedOperations(pn: PublicNoticeResponse) {
+    // Extra conversion for form: 'opStartDate' and 'opEndDate'
+    if (pn?.operationStartYear) {
+      this.opStartDate = moment().set('year', pn.operationStartYear)
+                                  .set('date', 1) // Does not matter for date, but set to first day for consistency later for comparison.
+                                  .toDate();
+    }
+    // Setting default year 
+    else {
+      this.opStartDate = moment().set('date', 1)
+                                  .toDate();
+    }
+
+    if (pn?.operationEndYear) {
+      this.opEndDate = moment().set('year', pn.operationEndYear)
+                                  .set('date', 1) // Does not matter for date, but set to first day for consistency later for comparison.
+                                  .toDate();
     }
   }
 }

--- a/api/openapi/swagger-spec.json
+++ b/api/openapi/swagger-spec.json
@@ -445,6 +445,12 @@
           "email": {
             "type": "string"
           },
+          "operationStartYear": {
+            "type": "number"
+          },
+          "operationEndYear": {
+            "type": "number"
+          },
           "project": {
             "$ref": "#/components/schemas/ProjectResponse"
           }
@@ -458,6 +464,8 @@
           "isReceiveCommentsSameAsReview",
           "mailingAddress",
           "email",
+          "operationStartYear",
+          "operationEndYear",
           "project"
         ]
       },
@@ -488,6 +496,12 @@
           "email": {
             "type": "string"
           },
+          "operationStartYear": {
+            "type": "number"
+          },
+          "operationEndYear": {
+            "type": "number"
+          },
           "revisionCount": {
             "type": "number"
           },
@@ -504,6 +518,8 @@
           "isReceiveCommentsSameAsReview",
           "mailingAddress",
           "email",
+          "operationStartYear",
+          "operationEndYear",
           "revisionCount",
           "id"
         ]
@@ -534,6 +550,12 @@
           },
           "email": {
             "type": "string"
+          },
+          "operationStartYear": {
+            "type": "number"
+          },
+          "operationEndYear": {
+            "type": "number"
           }
         },
         "required": [
@@ -544,7 +566,9 @@
           "receiveCommentsBusinessHours",
           "isReceiveCommentsSameAsReview",
           "mailingAddress",
-          "email"
+          "email",
+          "operationStartYear",
+          "operationEndYear"
         ]
       },
       "PublicNoticeUpdateRequest": {
@@ -574,6 +598,12 @@
           "email": {
             "type": "string"
           },
+          "operationStartYear": {
+            "type": "number"
+          },
+          "operationEndYear": {
+            "type": "number"
+          },
           "revisionCount": {
             "type": "number"
           }
@@ -587,6 +617,8 @@
           "isReceiveCommentsSameAsReview",
           "mailingAddress",
           "email",
+          "operationStartYear",
+          "operationEndYear",
           "revisionCount"
         ]
       },

--- a/api/src/app/modules/project/public-notice.dto.ts
+++ b/api/src/app/modules/project/public-notice.dto.ts
@@ -44,8 +44,8 @@ export class PublicNoticeCreateRequest {
 
   @ApiProperty({ required: true })
   @IsNumber()
-  @IsNotLessThan('operationStartYear', {
-    message: "[Operation End Year] must be the same or after [Operation Start Year]",
+  @IsGreaterOrEqualTo('operationStartYear', {
+    message: "[Proposed End of Operations] must be the same or after [Proposed Start of Operations]",
   })
   operationEndYear: number;
 }
@@ -73,12 +73,12 @@ export class PublicNoticePublicFrontEndResponse extends PublicNoticeCreateReques
 }
 
 /**
- * Custom validation decorator: @IsNotLessThan - check number_1 >= number_2
+ * Custom validation decorator: @IsGreaterOrEqualTo - check number_1 >= number_2
  */
-export function IsNotLessThan(property: string, validationOptions?: ValidationOptions) {
+export function IsGreaterOrEqualTo(property: string, validationOptions?: ValidationOptions) {
   return function (object: Object, propertyName: string) {
     registerDecorator({
-      name: 'isNotLessThan',
+      name: 'isGreaterOrEqualTo',
       target: object.constructor,
       propertyName: propertyName,
       constraints: [property],

--- a/api/src/app/modules/project/public-notice.dto.ts
+++ b/api/src/app/modules/project/public-notice.dto.ts
@@ -38,6 +38,13 @@ export class PublicNoticeCreateRequest {
   @MaxLength(100) 
   email: string;
   
+  @ApiProperty({ required: true })
+  @IsNumber()
+  operationStartYear: number;
+
+  @ApiProperty({ required: true })
+  @IsNumber()
+  operationEndYear: number;
 }
 
 export class PublicNoticeUpdateRequest extends PublicNoticeCreateRequest {

--- a/api/src/app/modules/project/public-notice.entity.ts
+++ b/api/src/app/modules/project/public-notice.entity.ts
@@ -39,4 +39,9 @@ export class PublicNotice extends ApiBaseEntity<PublicNotice> {
   @Column()
   email: string
 
+  @Column({ name: 'operation_start_year'})
+  operationStartYear: number;
+
+  @Column({ name: 'operation_end_year'})
+  operationEndYear: number;
 }

--- a/api/src/app/modules/project/public-notice.service.ts
+++ b/api/src/app/modules/project/public-notice.service.ts
@@ -125,7 +125,9 @@ export class PublicNoticeService extends DataService<PublicNotice, Repository<Pu
           'receiveCommentsBusinessHours',
           'isReceiveCommentsSameAsReview',
           'mailingAddress',
-          'email'
+          'email',
+          'operationStartYear',
+          'operationEndYear'
         ]
       ));
       response.project = this.projectService.convertEntity(entity.project);

--- a/api/src/app/modules/project/public-notice.service.ts
+++ b/api/src/app/modules/project/public-notice.service.ts
@@ -173,6 +173,8 @@ export class PublicNoticeService extends DataService<PublicNotice, Repository<Pu
     response.mailingAddress = entity.mailingAddress;
     response.email = entity.email;
     response.revisionCount = entity.revisionCount;
+    response.operationStartYear = entity.operationStartYear;
+    response.operationEndYear = entity.operationEndYear;
     return response;
   }
 

--- a/api/src/migrations/main/1661461702043-public-notice-addColumn-operationYears.js
+++ b/api/src/migrations/main/1661461702043-public-notice-addColumn-operationYears.js
@@ -1,0 +1,38 @@
+const { MigrationInterface, QueryRunner } = require("typeorm");
+
+module.exports = class publicNoticeAddColumnOperationYears1661461702043 {
+
+  async up(queryRunner) {
+    console.log('Starting public_notice (add new columns - operation_start_year, operation_end_year) migration');
+    await queryRunner.query(`
+
+    -- add new column - operation_start_year, nullable (for existing data before new column exists)
+      ALTER TABLE app_fom.public_notice ADD COLUMN operation_start_year integer;
+
+    -- add new column - operation_end_year, nullable (for existing data before new column exists)
+	    ALTER TABLE app_fom.public_notice ADD COLUMN operation_end_year integer;
+
+    -- comment on column - operation_start_year
+      COMMENT ON COLUMN app_fom.public_notice.operation_start_year IS
+        'Starting Year of planned duration of the FOM operations';
+      
+    -- comment on column - operation_end_year
+      COMMENT ON COLUMN app_fom.public_notice.operation_end_year IS
+        'Ending Year of planned duration of the FOM operations';
+
+    `);
+  }
+
+  async down(queryRunner) {
+    console.log('Starting public_notice (drop columns - operation_start_year, operation_end_year) migration');
+    await queryRunner.query(`
+
+    -- drop new columns - operation_start_year, operation_end_year
+        ALTER TABLE app_fom.public_notice DROP COLUMN operation_start_year;
+        ALTER TABLE app_fom.public_notice DROP COLUMN operation_end_year;
+
+    `);
+
+  }
+}
+        

--- a/libs/client/typescript-ng/.openapi-generator/FILES
+++ b/libs/client/typescript-ng/.openapi-generator/FILES
@@ -1,4 +1,5 @@
 .gitignore
+.openapi-generator-ignore
 README.md
 api.module.ts
 api/api.ts

--- a/libs/client/typescript-ng/model/publicNoticeCreateRequest.ts
+++ b/libs/client/typescript-ng/model/publicNoticeCreateRequest.ts
@@ -20,5 +20,7 @@ export interface PublicNoticeCreateRequest {
     isReceiveCommentsSameAsReview: boolean;
     mailingAddress: string;
     email: string;
+    operationStartYear: number;
+    operationEndYear: number;
 }
 

--- a/libs/client/typescript-ng/model/publicNoticePublicFrontEndResponse.ts
+++ b/libs/client/typescript-ng/model/publicNoticePublicFrontEndResponse.ts
@@ -21,6 +21,8 @@ export interface PublicNoticePublicFrontEndResponse {
     isReceiveCommentsSameAsReview: boolean;
     mailingAddress: string;
     email: string;
+    operationStartYear: number;
+    operationEndYear: number;
     project: ProjectResponse;
 }
 

--- a/libs/client/typescript-ng/model/publicNoticeResponse.ts
+++ b/libs/client/typescript-ng/model/publicNoticeResponse.ts
@@ -20,6 +20,8 @@ export interface PublicNoticeResponse {
     isReceiveCommentsSameAsReview: boolean;
     mailingAddress: string;
     email: string;
+    operationStartYear: number;
+    operationEndYear: number;
     revisionCount: number;
     id: number;
 }

--- a/libs/client/typescript-ng/model/publicNoticeUpdateRequest.ts
+++ b/libs/client/typescript-ng/model/publicNoticeUpdateRequest.ts
@@ -20,6 +20,8 @@ export interface PublicNoticeUpdateRequest {
     isReceiveCommentsSameAsReview: boolean;
     mailingAddress: string;
     email: string;
+    operationStartYear: number;
+    operationEndYear: number;
     revisionCount: number;
 }
 

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.html
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.html
@@ -120,13 +120,8 @@
       </div>
 
       <div class="row" *ngIf="pn.operationStartYear && pn.operationEndYear">
-        <div class="col-sm-4 bold">Operation Start Year: </div>
-        <div class="col-sm-8">{{pn.operationStartYear}}</div>
-      </div>
-
-      <div class="row" *ngIf="pn.operationEndYear && pn.operationEndYear">
-        <div class="col-sm-4 bold">Operation End Year: </div>
-        <div class="col-sm-8">{{pn.operationEndYear}}</div>
+        <div class="col-sm-4 bold">Proposed Period of Operations: </div>
+        <div class="col-sm-8">{{pn.operationStartYear}} - {{pn.operationEndYear}}</div>
       </div>
 
       <div class="row">

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.html
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.html
@@ -119,6 +119,16 @@
         <div class="col-sm-8">{{pn.project.commentingOpenDate | date: 'longDate'}} to {{pn.project.validityEndDate | date: 'longDate'}}</div>
       </div>
 
+      <div class="row" *ngIf="pn.operationStartYear && pn.operationEndYear">
+        <div class="col-sm-4 bold">Operation Start Year: </div>
+        <div class="col-sm-8">{{pn.operationStartYear}}</div>
+      </div>
+
+      <div class="row" *ngIf="pn.operationEndYear && pn.operationEndYear">
+        <div class="col-sm-4 bold">Operation End Year: </div>
+        <div class="col-sm-8">{{pn.operationEndYear}}</div>
+      </div>
+
       <div class="row">
         <div class="col-sm-4 bold">FOM Summary: </div>
         <div class="col-sm-8">{{pn.project.name}}</div>
@@ -165,12 +175,14 @@
         <div class="col-sm-8">{{pn.email}}</div>
       </div>
 
+      <div class="validity-txt" *ngIf="pn.operationStartYear && pn.operationEndYear">
+        Road construction and harvesting of cutblocks depicted on this Forest Operations Map is scheduled to be conducted between {{pn.operationStartYear}} and {{pn.operationEndYear}}.
+      </div>
+
       <div class="validity-txt">
-        <div>
-          This FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road
-          permit application, or the issuance of a Timber Sales License until the date three years
-          after commencement of the public review and commenting period.
-        </div>
+        This FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road
+        permit application, or the issuance of a Timber Sales License until the date three years
+        after commencement of the public review and commenting period.
       </div>
 
     </ng-template>

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.html
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.html
@@ -166,7 +166,7 @@
       </div>
 
       <div class="validity-txt">
-        <div style="margin-bottom: 15px;">
+        <div>
           This FOM can be relied upon by the FOM holder for the purpose of a cutting permit or road
           permit application, or the issuance of a Timber Sales License until the date three years
           after commencement of the public review and commenting period.

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.scss
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.scss
@@ -37,6 +37,7 @@
 .validity-txt {
   margin-top: 2rem;
   font-size: 0.85rem;
+  margin-bottom: 15px;
 }
 
 .filter-panel {


### PR DESCRIPTION
- This change is related to task: https://app.zenhub.com/workspaces/fsa-fingerprint-61f04f08304d3e001a4f2578/issues/bcgov/nr-fom/222 and https://app.zenhub.com/workspaces/fsa-fingerprint-61f04f08304d3e001a4f2578/issues/bcgov/nr-fom/203
- Migration script for public_notice (add new columns - operation_start_year, operation_end_year)
- Add fields (operationStartYear, operationEndYear) to entity and dto classes.
- Add custom IsNotLessThan validation decorator for endpoint validation and message.
- Generate new api-client for frontend.
- Add date picker to select years for operation_start_year and operation_end_year at admin public.
- Add validation for these two fields as required and operation_end_year >= operation_start_year (however, there is an unknown bug when setting default, so leave both blank)
- Add operation_start_year and operation_end_year fields at public side frontend public notice page and its business statement.