### PR TITLE
Feat/operation years latest from client remove previous years

### DIFF
--- a/admin/src/app/foms/public-notice/public-notice-edit.component.ts
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.ts
@@ -87,6 +87,11 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
       .subscribe((result) => {
         this.project = result.data.projectDetail;
         this.publicNoticeResponse = result.publicNotice;
+        if (this.isNewForm) {
+          // Don't inherit operation years from previous public notice from the forest client.
+          delete this.publicNoticeResponse.operationStartYear;
+          delete this.publicNoticeResponse.operationEndYear;
+        }
         let publicNoticeForm = new PublicNoticeForm(this.publicNoticeResponse);
         this.publicNoticeFormGroup = this.formBuilder.formGroup(publicNoticeForm);
         this.onSameAsReviewIndToggled();

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.ts
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.ts
@@ -89,8 +89,8 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
         this.publicNoticeResponse = result.publicNotice;
         if (this.isNewForm) {
           // Don't inherit operation years from previous public notice from the forest client.
-          delete this.publicNoticeResponse.operationStartYear;
-          delete this.publicNoticeResponse.operationEndYear;
+          delete this.publicNoticeResponse?.operationStartYear;
+          delete this.publicNoticeResponse?.operationEndYear;
         }
         let publicNoticeForm = new PublicNoticeForm(this.publicNoticeResponse);
         this.publicNoticeFormGroup = this.formBuilder.formGroup(publicNoticeForm);


### PR DESCRIPTION
# Description
When user create a new Public Notice, and when app is pulling from the latest Public Notice for that forest client user, we don't want to also copy the previous operation years into the input form.

Fixes # (issue)
Let frontend do the conditional logic instead of backend refactoring to remove operation years from pulled data. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
