### PR TITLE
PRs fall back to TEST images, not PROD

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -90,13 +90,13 @@ jobs:
           done < <(git diff origin/main --name-only)
           echo "Container build not required"
 
-      - name: Recycle/retag PROD Image
+      - name: Recycle/retag TEST Image
         if: steps.check.outputs.build != 'true'
         uses: shrink/actions-docker-registry-tag@v2
         with:
           registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
-          target: prod-${{ env.TARGET }}
+          target: test-${{ env.TARGET }}
           tags: |
             ${{ github.event.number }}-${{ env.TARGET }}
 
@@ -134,13 +134,13 @@ jobs:
           done < <(git diff origin/main --name-only)
           echo "Container build not required"
 
-      - name: Recycle/retag PROD Image
+      - name: Recycle/retag TEST Image
         if: steps.check.outputs.build != 'true'
         uses: shrink/actions-docker-registry-tag@v2
         with:
           registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
-          target: prod-${{ env.TARGET }}
+          target: test-${{ env.TARGET }}
           tags: |
             ${{ github.event.number }}-${{ env.TARGET }}
 


### PR DESCRIPTION
PRs had been either building images or reusing ones from PROD.  Some teams are not going to PROD frequently, so it makes sense to use TEST images instead.