### PR TITLE
Upgrade GHA actions/checkout to v3 for node 12 deprecation

### DIFF
--- a/.github/workflows/merge-demo.yml
+++ b/.github/workflows/merge-demo.yml
@@ -25,7 +25,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -66,7 +66,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -107,7 +107,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -148,7 +148,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -193,7 +193,7 @@ jobs:
       URL: fom-demo.apps.silver.devops.gov.bc.ca
       ZONE: demo
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Deploy
         run: |
           set -eux

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -27,7 +27,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize
         uses: github/codeql-action/init@v2
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master
@@ -67,7 +67,7 @@ jobs:
     name: Static Analysis
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         # Disable shallow clone for SonarCloud analysis
         with:
           fetch-depth: 0
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Backend container scan
       - name: Trivy Image Scan
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Backend container scan
       - name: Trivy Image Scan
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Backend container scan
       - name: Trivy Image Scan
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@0.3.0
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Trivy Vulnerability Scan
         uses: aquasecurity/trivy-action@0.3.0
@@ -224,7 +224,7 @@ jobs:
       URL: fom-test.nrs.gov.bc.ca
       ZONE: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Deploy
         run: |
           set -eux
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.3.0
@@ -306,7 +306,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.3.0
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.3.0
@@ -348,7 +348,7 @@ jobs:
       IMG: ${{ github.repository }}:test
       URL: fom.nrs.gov.bc.ca
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Deploy
         run: |
           set -eux

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       NAME: fom
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Remove OpenShift artifacts
         run: |
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check and process modified files
         id: check
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check and process modified files
         id: check
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check and process modified files
         id: check
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check and process modified files
         id: check
@@ -199,7 +199,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -249,7 +249,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -299,7 +299,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -349,7 +349,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -396,7 +396,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get npm cache directory
         id: npm-cache-dir
@@ -446,7 +446,7 @@ jobs:
       needs.build-admin.result == 'success' || needs.build-public.result == 'success')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         # Disable shallow clone for SonarCloud analysis
         with:
           fetch-depth: 0
@@ -492,7 +492,7 @@ jobs:
       URL: fom-${{ github.event.number }}.apps.silver.devops.gov.bc.ca
       ZONE: ${{ github.event.number }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Deploy
         run: |
           # Login to OpenShift and select project


### PR DESCRIPTION
Node 12 is out of support.  Two actions in this repo use it.  One has been upgraded and the current release version provided in this PR.  We have until summer 2023 to address the second one.

Multiple repos will be receiving deprecation messages.  This is normal.

If the repo does not update to node 16 by summer 2023 we will find a replacement or write our own action.  Future activity will be happening in the helpers repo.  Please expect another PR addressing this, but not any time soon.

GitHub Release
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

QuickStart Helpers
https://github.com/bcgov/nr-quickstart-helpers

actions/checkout (upgraded)
https://github.com/actions/checkout

shrink/actions-docker-registry-tag (upgrade TBD)
https://github.com/shrink/actions-docker-registry-tag