### PR TITLE
Dependabot for Github Actions only (so far)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Dependency updates for GitHub Actions and npm
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
There are a number of breaks in this repo's workflows.  Let's start by updating the GitHub Actions versions.  This PR opts-in to using Dependabot, but just for those Actions.  We can look at npm later, but that'll probably create 80+ PRs.  (see security alerts)