### PR TITLE
Replace images

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -11,12 +11,9 @@ ARG build_dir
 WORKDIR /app
 COPY ./libs ./libs
 COPY ./${build_dir} ./${build_dir}
-RUN cd libs && \
-    npm ci && \
-    cd ../${build_dir} && \
-    npm ci && \
-    npm run build:${build_dir} && \
-    rm -rf node_modules ../libs/node_modules
+RUN pushd libs && npm ci && popd && \
+    pushd ${build_dir} && npm ci && npm run build:${build_dir} && popd && \
+    rm -rf libs/node_modules ${build_dir}/node_modules
 
 
 # Deploy container

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -11,8 +11,8 @@ ARG build_dir
 WORKDIR /app
 COPY ./libs ./libs
 COPY ./${build_dir} ./${build_dir}
-RUN pushd libs && npm ci && popd && \
-    pushd ${build_dir} && npm ci && npm run build:${build_dir} && popd && \
+RUN cd libs && npm ci && cd .. && \
+    cd ${build_dir} && npm ci && npm run build:${build_dir} && cd .. && \
     rm -rf libs/node_modules ${build_dir}/node_modules
 
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,14 +1,13 @@
 # RedHat UBI 8 with nodejs 14
-FROM registry.access.redhat.com/ubi8/nodejs-14:1-75.1652296492 as builder
+FROM registry.access.redhat.com/ubi8/nodejs-14:1-75.1652296492 AS builder
 
 # Install packages, build and keep only prod packages
 WORKDIR /app
 COPY . ./
 USER root
 RUN dnf install -y ca-certificates && \
-    cd libs && npm ci && \
-    cd ../api && npm ci && \
-    npm run build:api
+    pushd libs && npm ci && popd && \
+    cd api && npm ci && npm run build:api
 
 # Deployment container
 FROM registry.access.redhat.com/ubi8/ubi-micro

--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -11,12 +11,9 @@ ARG build_dir
 WORKDIR /app
 COPY ./libs ./libs
 COPY ./${build_dir} ./${build_dir}
-RUN cd libs && \
-    npm ci && \
-    cd ../${build_dir} && \
-    npm ci && \
-    npm run build:${build_dir} && \
-    rm -rf node_modules ../libs/node_modules
+RUN pushd libs && npm ci && popd && \
+    pushd ${build_dir} && npm ci && npm run build:${build_dir} && popd && \
+    rm -rf libs/node_modules ${build_dir}/node_modules
 
 
 # Deploy container

--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -11,8 +11,8 @@ ARG build_dir
 WORKDIR /app
 COPY ./libs ./libs
 COPY ./${build_dir} ./${build_dir}
-RUN pushd libs && npm ci && popd && \
-    pushd ${build_dir} && npm ci && npm run build:${build_dir} && popd && \
+RUN cd libs && npm ci && cd .. && \
+    cd ${build_dir} && npm ci && npm run build:${build_dir} && cd .. && \
     rm -rf libs/node_modules ${build_dir}/node_modules
 
 


### PR DESCRIPTION
Docker pull issue is cauling API pulls to fail.  This is an attempt to fix that by recreating the API image in ghcr.io.

Update: also affecting admin and public, db seems okay