### PR TITLE
Disable Dependabot for switch to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-# Dependency updates for GitHub Actions and npm
-# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
Disable Dependabot for switch to Renovate.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-323.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-323.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-323.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)