### PR TITLE
Fix: #332 fix missing update Cognito token when token is refreshed during interceptor

### DIFF
--- a/admin/src/core/services/cognito.service.ts
+++ b/admin/src/core/services/cognito.service.ts
@@ -120,6 +120,7 @@ export class CognitoService {
     return new Observable((observer) => {
       Auth.currentSession()
         .then((refreshed) => {
+          this.cognitoAuthToken = this.parseToken(refreshed);
           observer.next();
           observer.complete();
         })


### PR DESCRIPTION
This PR is to fix #332.
Current logged in user token would expire after 5 minutes and the backend checks for that so the user at frontend will face 403 error and will need to logout and in again.
PR detail:
- Fix frontend missing update on CognitoService's token, during refreshing token, so the Interceptor can grab the token to be used for the subsequent request and allow user to continue work on current session.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-333.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-333.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-333.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)