### PR TITLE
Angular15 - typed form

### DIFF
--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
@@ -1,10 +1,10 @@
 import { MAX_FILEUPLOAD_SIZE } from '@admin-core/utils/constants/constantUtils';
-import { Component, Input, OnInit } from '@angular/core';
-import { FormsModule, ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
+import { Component, Input } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AttachmentResponse, AttachmentService, InteractionResponse } from '@api-client';
-import { RxFormBuilder } from '@rxweb/reactive-form-validators';
+import { IFormGroup, RxFormBuilder } from '@rxweb/reactive-form-validators';
 import { ConfigService } from '@utility/services/config.service';
-import { InteractionDetailForm } from './interaction-detail.form';
+import { InteractionDetailForm, InteractionRequest } from './interaction-detail.form';
 
 import { UploadBoxComponent } from '@admin-core/components/file-upload-box/file-upload-box.component';
 import { DatePipe, NgClass, NgIf } from '@angular/common';
@@ -26,7 +26,7 @@ import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
     styleUrls: ['./interaction-detail.component.scss'],
     exportAs: 'interactionForm'
 })
-export class InteractionDetailComponent implements OnInit {
+export class InteractionDetailComponent {
 
   today = new Date();
   maxDate = this.today;
@@ -34,7 +34,7 @@ export class InteractionDetailComponent implements OnInit {
   @Input()
   editMode: boolean;
 
-  interactionFormGroup: UntypedFormGroup;
+  interactionFormGroup: IFormGroup<InteractionRequest>;
   
   files: any[] = []; // Array type, but only 1 attachment for Interaction.
   maxFileSize: number = MAX_FILEUPLOAD_SIZE.DOCUMENT;
@@ -56,14 +56,10 @@ export class InteractionDetailComponent implements OnInit {
     private attachmentSvc: AttachmentService
   ) { }
 
-  ngOnInit(): void {
-    // Blank method is intentional
-  }
-
   @Input() set selectedInteraction(interaction: InteractionResponse) {
     this.interaction = interaction;
     const interactionForm = new InteractionDetailForm(interaction)
-    this.interactionFormGroup = this.formBuilder.formGroup(interactionForm);
+    this.interactionFormGroup = this.formBuilder.formGroup(interactionForm)as IFormGroup<InteractionRequest>;
     if (!this.editMode) {
       this.interactionFormGroup.disable();
     }

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.ts
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.ts
@@ -3,13 +3,13 @@ import { ModalService } from '@admin-core/services/modal.service';
 import { StateService } from '@admin-core/services/state.service';
 import { NgClass, NgIf } from "@angular/common";
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { FormsModule, ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
     ProjectResponse, PublicNoticeCreateRequest, PublicNoticeResponse,
     PublicNoticeService, PublicNoticeUpdateRequest, WorkflowStateEnum
 } from '@api-client';
-import { RxFormBuilder } from '@rxweb/reactive-form-validators';
+import { IFormGroup, RxFormBuilder } from '@rxweb/reactive-form-validators';
 import { User } from "@utility/security/user";
 import { BsDatepickerConfig, BsDatepickerModule } from "ngx-bootstrap/datepicker";
 import { Subject, lastValueFrom } from 'rxjs';
@@ -36,7 +36,7 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
   projectId: number;
   isNewForm: boolean;
   publicNoticeResponse: PublicNoticeResponse;
-  publicNoticeFormGroup: UntypedFormGroup;
+  publicNoticeFormGroup: IFormGroup<PublicNoticeForm>;
   addressLimit: number = 500;
   businessHoursLimit: number = 100;
   editMode: boolean; // 'edit'/'view' mode.
@@ -104,7 +104,7 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
           delete this.publicNoticeResponse?.operationEndYear;
         }
         let publicNoticeForm = new PublicNoticeForm(this.publicNoticeResponse);
-        this.publicNoticeFormGroup = this.formBuilder.formGroup(publicNoticeForm);
+        this.publicNoticeFormGroup = this.formBuilder.formGroup(publicNoticeForm) as IFormGroup<PublicNoticeForm>;
         this.onSameAsReviewIndToggled();
         if (!this.editMode) {
           this.publicNoticeFormGroup.disable();
@@ -194,10 +194,10 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
   private submitPublicNotice() {
     let body: any;
     if (this.isAddNewNotice()) {
-      body = this.publicNoticeFormGroup.value as PublicNoticeCreateRequest;
+      body = this.publicNoticeFormGroup.value as Partial<PublicNoticeCreateRequest>;
     }
     else {
-      body = this.publicNoticeFormGroup.value as PublicNoticeUpdateRequest;
+      body = this.publicNoticeFormGroup.value as Partial<PublicNoticeUpdateRequest>;
       body.revisionCount = this.publicNoticeResponse.revisionCount;
     }
 

--- a/admin/src/app/foms/review-comments/comment-detail/comment-detail.component.ts
+++ b/admin/src/app/foms/review-comments/comment-detail/comment-detail.component.ts
@@ -1,8 +1,8 @@
 import { StateService } from '@admin-core/services/state.service';
 import { Component, Input } from '@angular/core';
-import { FormsModule, ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommentScopeCode, PublicCommentAdminResponse, ResponseCode } from '@api-client';
-import { RxFormBuilder } from '@rxweb/reactive-form-validators';
+import { IFormGroup, RxFormBuilder } from '@rxweb/reactive-form-validators';
 import * as _ from 'lodash';
 import { CommentDetailForm } from './comment-detail.form';
 
@@ -26,7 +26,7 @@ import { DatePipe, NgFor, NgIf } from '@angular/common';
 })
 export class CommentDetailComponent {
   commentScopeCodes: _.Dictionary<CommentScopeCode>;
-  commentFormGroup: UntypedFormGroup;
+  commentFormGroup: IFormGroup<CommentDetailForm>;
   comment: PublicCommentAdminResponse;
   responseDetailsLimit: number = 4000;
 
@@ -36,7 +36,7 @@ export class CommentDetailComponent {
   @Input() set selectedComment(comment: PublicCommentAdminResponse) {
     this.comment = comment;
     const commentFormGroup = new CommentDetailForm(comment)
-    this.commentFormGroup = this.formBuilder.formGroup(commentFormGroup);
+    this.commentFormGroup = this.formBuilder.formGroup(commentFormGroup) as IFormGroup<CommentDetailForm>;
     if (!this.canReplyComment) {
       this.commentFormGroup.disable();
     }

--- a/admin/src/app/foms/review-comments/comment-detail/comment-detail.form.ts
+++ b/admin/src/app/foms/review-comments/comment-detail/comment-detail.form.ts
@@ -1,5 +1,5 @@
-import {prop, required} from "@rxweb/reactive-form-validators"
-import {PublicCommentAdminResponse, PublicCommentAdminUpdateRequest, ResponseCodeEnum} from "@api-client";
+import { PublicCommentAdminResponse, PublicCommentAdminUpdateRequest, ResponseCodeEnum } from "@api-client";
+import { prop, required } from "@rxweb/reactive-form-validators";
 
 const UPDATE_FIELDS = ['responseDetails', 'responseCode'] as const;
 
@@ -11,9 +11,13 @@ export class CommentDetailForm implements Pick<PublicCommentAdminUpdateRequest, 
   @required()
   responseCode: ResponseCodeEnum;
 
+  @prop()
+  revisionCount: number;
+
   constructor(comment: PublicCommentAdminResponse) {
     this.responseCode = comment.response?.code as ResponseCodeEnum;
     this.responseDetails = comment.responseDetails;
+    this.revisionCount = comment.revisionCount;
   }
 
 }

--- a/admin/src/app/foms/review-comments/review-comments.component.ts
+++ b/admin/src/app/foms/review-comments/review-comments.component.ts
@@ -2,6 +2,8 @@ import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/co
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Observable, Subject } from 'rxjs';
 
+import { CognitoService } from "@admin-core/services/cognito.service";
+import { StateService } from '@admin-core/services/state.service';
 import { CommonUtil } from '@admin-core/utils/commonUtil';
 import { COMMENT_SCOPE_CODE, CommentScopeOpt } from '@admin-core/utils/constants/constantUtils';
 import { AsyncPipe, DatePipe, NgFor, NgIf } from '@angular/common';
@@ -16,8 +18,6 @@ import {
 import { User } from "@utility/security/user";
 import * as _ from 'lodash';
 import { map, takeUntil } from 'rxjs/operators';
-import { CognitoService } from "@admin-core/services/cognito.service";
-import { StateService } from '@admin-core/services/state.service';
 import { CommentDetailComponent } from './comment-detail/comment-detail.component';
 
 export const ERROR_DIALOG = {
@@ -157,7 +157,6 @@ export class ReviewCommentsComponent implements OnInit, OnDestroy {
       return;
     }
     const {id} = selectedComment;
-    update.revisionCount = selectedComment.revisionCount;
 
     try {
       this.loading = true;

--- a/api/src/app/modules/attachment/attachment.controller.ts
+++ b/api/src/app/modules/attachment/attachment.controller.ts
@@ -77,6 +77,7 @@ export class AttachmentController {
 
   @Get('/file/:id')
   @ApiBearerAuth()
+  @AuthGuardMeta(GUARD_OPTIONS.PUBLIC)
   @ApiOkResponse() 
   async getFileContents(
     @UserHeader() user: User,


### PR DESCRIPTION
This is the Angular 14 strict typed form feature migration from temporary "**UntypedForm**" type added from "ng upgrade" during the upgrade to the **specific form type**. Link this PR to #346.
There are few "admin" reactive forms upgraded.

Note, this also includes a fix for previous broken "admin" side **file download** from "FOM Detail" page. Open up at backend api as "Public" endpoint for now.