### PR TITLE
Fix/api interaction class validator is date string issue

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -37,7 +37,7 @@
         "typeorm": "^0.3.15"
       },
       "devDependencies": {
-        "@nestjs/cli": "^9.4.0",
+        "@nestjs/cli": "~9.4.0",
         "@nestjs/schematics": "^9.1.0",
         "@nestjs/testing": "^9.4.0",
         "@openapitools/openapi-generator-cli": "^2.6.0",
@@ -1500,6 +1500,19 @@
         "node": ">= 12.9.0"
       }
     },
+    "node_modules/@nestjs/cli/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@nestjs/common": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.4.0.tgz",
@@ -2367,9 +2380,9 @@
       "dev": true
     },
     "node_modules/@types/validator": {
-      "version": "13.7.15",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.15.tgz",
-      "integrity": "sha512-yeinDVQunb03AEP8luErFcyf/7Lf7AzKCD0NXfgVoGCCQDNpZET8Jgq74oBgqKld3hafLbfzt/3inUdQvaFeXQ=="
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -11471,9 +11484,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13307,6 +13320,14 @@
         "typescript": "4.9.5",
         "webpack": "5.79.0",
         "webpack-node-externals": "3.0.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        }
       }
     },
     "@nestjs/common": {
@@ -13942,9 +13963,9 @@
       "dev": true
     },
     "@types/validator": {
-      "version": "13.7.15",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.15.tgz",
-      "integrity": "sha512-yeinDVQunb03AEP8luErFcyf/7Lf7AzKCD0NXfgVoGCCQDNpZET8Jgq74oBgqKld3hafLbfzt/3inUdQvaFeXQ=="
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ=="
     },
     "@types/yargs": {
       "version": "17.0.24",
@@ -20929,9 +20950,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "devOptional": true
     },
     "uc.micro": {

--- a/api/package.json
+++ b/api/package.json
@@ -50,7 +50,7 @@
     "typeorm": "^0.3.15"
   },
   "devDependencies": {
-    "@nestjs/cli": "^9.4.0",
+    "@nestjs/cli": "~9.4.0",
     "@nestjs/schematics": "^9.1.0",
     "@nestjs/testing": "^9.4.0",
     "@openapitools/openapi-generator-cli": "^2.6.0",

--- a/api/src/app/modules/interaction/interaction.dto.ts
+++ b/api/src/app/modules/interaction/interaction.dto.ts
@@ -26,7 +26,7 @@ export class InteractionCreateRequest {
   stakeholder: string;
 
   @ApiProperty({ required: true })
-  @IsDateString(null, {message: '"$property" must be ISO-formatted date.'})
+  @IsDateString({}, {message: '"$property" must be ISO-formatted date.'})
   @IsNotEmpty()
   communicationDate?: string;
 


### PR DESCRIPTION
Error at 'admin' staff engagement page arise when submitting the new interaction.
Backend "class-validator" fail with date string in particular (and only in this component due to specially calling class-validator validate function).
The upgrade of "class-validator' has its `@IsDateString` signature change that causes this issue.
* This PR fix this issue.
* This PR also address problem seen in Windows OS conflicts with NestJS CLI (with certain Typescript version, > 4.9). So minor adjustment to package.json for allowing only 'patch' version instead of 'minor' version for NestJS. We don't need to restrict Typescript version.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-366.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-366.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-366.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)