### PR TITLE
fix: Remove project controller TypeORM relation overriding the common relation so project.find…

### DIFF
--- a/api/src/app/modules/project/project.controller.ts
+++ b/api/src/app/modules/project/project.controller.ts
@@ -70,9 +70,7 @@ export class ProjectController {
   async findOne(
     @UserHeader() user: User,
     @Param('id', ParseIntPipe) id: number): Promise<ProjectResponse> {
-    return this.service.findOne(id, user, {
-      relations: ['district', 'forestClient', 'workflowState'],
-    });
+    return this.service.findOne(id, user);
   }
 
   @Get('/metrics/:id')


### PR DESCRIPTION
The issue for public notice to load in project response at frontend is having problem.
Remove this relation options that overriding the common relation so it returns the public notice id.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-367.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-367.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-367.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)