### PR TITLE
fix: Use Angular specific event listener to prevent manual entering

### DIFF
--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.html
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.html
@@ -58,7 +58,7 @@
                 placeholder="YYYY-MM-DD"
                 bsDatepicker
                 [minDate]="minOpeningDate"
-                onkeydown="return false"
+                (keydown)="$event.preventDefault()"
                 #openDate="bsDatepicker"
                 id="commentingOpenDate"
                 name="commentingOpenDate"
@@ -86,7 +86,7 @@
                 placeholder="YYYY-MM-DD"
                 bsDatepicker
                 [minDate]="minClosedDate"
-                onkeydown="return false"
+                (keydown)="$event.preventDefault()"
                 #closedDate="bsDatepicker"
                 id="commentingClosedDate"
                 name="commentingClosedDate"

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
@@ -29,6 +29,7 @@
           formControlName="communicationDate"
           [maxDate]="maxDate"
           readonly
+          (keydown)="$event.preventDefault()"
           [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD', adaptivePosition: true,
           containerClass: 'theme-dark-blue', showWeekNumbers: false  }"
         />

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.html
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.html
@@ -159,7 +159,7 @@
             placeholder="YYYY"
             formControlName="opStartDate"
             bsDatepicker
-            onkeydown="return false"
+            (keydown)="$event.preventDefault()"
             [bsConfig]="bsConfig"
           />
           <div class="invalid-feedback" 
@@ -183,7 +183,7 @@
             placeholder="YYYY"
             formControlName="opEndDate"
             bsDatepicker
-            onkeydown="return false"
+            (keydown)="$event.preventDefault()"
             [bsConfig]="bsConfig"
           />
           <div class="invalid-feedback" 


### PR DESCRIPTION
Use Angular specific event listener to prevent manual entering for input.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-369.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-369.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-369.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)