### PR TITLE
fix: #371 FOM (admin) - Updating Stakeholder Engagement is Causing Issue to Backend Date(s) Validation for Selected Date on Commenting Open Date.

### DIFF
--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
@@ -28,6 +28,7 @@
           name="communicationDate"
           formControlName="communicationDate"
           [maxDate]="maxDate"
+          [minDate]="minDate"
           readonly
           (keydown)="$event.preventDefault()"
           [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD', adaptivePosition: true,

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
@@ -33,6 +33,8 @@ export class InteractionDetailComponent {
   interaction: InteractionResponse;
   @Input()
   editMode: boolean;
+  @Input()
+  minDate: Date;
 
   interactionFormGroup: IFormGroup<InteractionRequest>;
   

--- a/admin/src/app/foms/interactions/interactions.component.ts
+++ b/admin/src/app/foms/interactions/interactions.component.ts
@@ -117,6 +117,7 @@ export class InteractionsComponent implements OnInit, OnDestroy {
 
   async saveInteraction(saveReq: InteractionRequest, selectedInteraction: InteractionResponse) {
     const {id} = selectedInteraction;
+    saveReq.communicationDate = moment(saveReq.communicationDate).format('YYYY-MM-DD'); // convert datePicker value to YYYY-MM-DD string.
     const resultPromise = this.prepareSaveRequest(id, this.projectId, saveReq, selectedInteraction);
     resultPromise
       .then((result) => this.handleSaveSuccess(result))

--- a/admin/src/app/foms/interactions/interactions.component.ts
+++ b/admin/src/app/foms/interactions/interactions.component.ts
@@ -1,12 +1,13 @@
+import { CognitoService } from "@admin-core/services/cognito.service";
+import { ModalService } from '@admin-core/services/modal.service';
 import { AsyncPipe, DatePipe, NgFor, NgIf } from '@angular/common';
 import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { InteractionResponse, InteractionService, ProjectResponse, WorkflowStateEnum } from '@api-client';
 import { User } from "@utility/security/user";
+import * as moment from 'moment';
 import { Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { CognitoService } from "@admin-core/services/cognito.service";
-import { ModalService } from '@admin-core/services/modal.service';
 import { InteractionDetailComponent } from './interaction-detail/interaction-detail.component';
 import { InteractionRequest } from './interaction-detail/interaction-detail.form';
 
@@ -89,6 +90,7 @@ export class InteractionsComponent implements OnInit, OnDestroy {
     this.selectedItem = item;
     this.interactionDetailForm.editMode = this.canModifyInteraction(); // set this first.
     this.interactionDetailForm.selectedInteraction = item;
+    this.interactionDetailForm.minDate = moment(this.project.commentingOpenDate).toDate();
     if (pos) {
       // !! important to wait or will not see the effect.
       setTimeout(() => {
@@ -110,6 +112,7 @@ export class InteractionsComponent implements OnInit, OnDestroy {
     this.selectedItem = null;
     this.interactionDetailForm.editMode = this.canModifyInteraction(); // set this first.
     this.interactionDetailForm.selectedInteraction = {} as InteractionResponse;
+    this.interactionDetailForm.minDate = moment(this.project.commentingOpenDate).toDate();
   }
 
   async saveInteraction(saveReq: InteractionRequest, selectedInteraction: InteractionResponse) {

--- a/admin/src/app/foms/interactions/interactions.component.ts
+++ b/admin/src/app/foms/interactions/interactions.component.ts
@@ -90,7 +90,7 @@ export class InteractionsComponent implements OnInit, OnDestroy {
     this.selectedItem = item;
     this.interactionDetailForm.editMode = this.canModifyInteraction(); // set this first.
     this.interactionDetailForm.selectedInteraction = item;
-    this.interactionDetailForm.minDate = moment(this.project.commentingOpenDate).toDate();
+    this.setMinDate();
     if (pos) {
       // !! important to wait or will not see the effect.
       setTimeout(() => {
@@ -112,6 +112,10 @@ export class InteractionsComponent implements OnInit, OnDestroy {
     this.selectedItem = null;
     this.interactionDetailForm.editMode = this.canModifyInteraction(); // set this first.
     this.interactionDetailForm.selectedInteraction = {} as InteractionResponse;
+    this.setMinDate();
+  }
+
+  setMinDate() {
     this.interactionDetailForm.minDate = moment(this.project.commentingOpenDate).toDate();
   }
 

--- a/api/src/app/modules/interaction/interaction.controller.ts
+++ b/api/src/app/modules/interaction/interaction.controller.ts
@@ -115,15 +115,15 @@ export class InteractionController {
     @Req() request: fetch.Request): Promise<InteractionResponse> {
       /** temp logging */
       this.logger.info(`InteractionController: creating...`)
-      this.logger.info(`InteractionController: request...`, request)
-      this.logger.info("InteractionController: request.body['communicationDate']: ", request.body['communicationDate'])
+      this.logger.info(`InteractionController: request... %o`, request)
+      this.logger.info("InteractionController: request.body['communicationDate']: %o", request.body['communicationDate'])
 
       const reqDate = _.isEmpty(request.body['communicationDate'])
                       ? null
                       : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
                         DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
       /** temp logging */
-      this.logger.info("InteractionController: transformed reqDate: ", reqDate)
+      this.logger.info("InteractionController: transformed reqDate: %o", reqDate)
 
       const createRequest = new InteractionCreateRequest(
         await new ParseIntPipe().transform(request.body['projectId'], null),
@@ -168,15 +168,15 @@ export class InteractionController {
     @Req() request: fetch.Request): Promise<InteractionResponse> {
       /** temp logging */
       this.logger.info(`InteractionController: updating...`)
-      this.logger.info(`InteractionController: request...`, request)
-      this.logger.info("InteractionController: request.body['communicationDate']: ", request.body['communicationDate'])
+      this.logger.info(`InteractionController: request... %o`, request)
+      this.logger.info("InteractionController: request.body['communicationDate']: %o", request.body['communicationDate'])
 
       const reqDate = _.isEmpty(request.body['communicationDate'])
                       ? null
                       : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
                         DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
       /** temp logging */
-      this.logger.info("InteractionController: transformed reqDate: ", reqDate)
+      this.logger.info("InteractionController: transformed reqDate: %o", reqDate)
                    
       const updateRequest = new InteractionUpdateRequest(
         await new ParseIntPipe().transform(request.body['projectId'], null),

--- a/api/src/app/modules/interaction/interaction.controller.ts
+++ b/api/src/app/modules/interaction/interaction.controller.ts
@@ -1,4 +1,4 @@
-import { DateTimeUtil } from '@api-core/dateTimeUtil';
+import { AuthGuard, UserHeader } from '@api-core/security/auth.guard';
 import { BadRequestException, Controller, Delete, Get, HttpStatus, Param, ParseIntPipe, Post, Put, Query, Req, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiBearerAuth, ApiBody, ApiConsumes, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -13,7 +13,6 @@ import { InteractionCreateRequest, InteractionResponse, InteractionUpdateRequest
 import { InteractionService } from './interaction.service';
 import _ = require('lodash');
 import dayjs = require('dayjs');
-import { AuthGuard, UserHeader } from '@api-core/security/auth.guard';
 // initialize dayjs extensions
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -118,20 +117,10 @@ export class InteractionController {
       this.logger.info(`InteractionController: request... %o`, request)
       this.logger.info("InteractionController: request.body['communicationDate']: %o", request.body['communicationDate'])
 
-    //   const reqDate = _.isEmpty(request.body['communicationDate'])
-    //                   ? null
-    //                   : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
-    //                     DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
-    
-      const reqDate = this.toLocalDate(request.body['communicationDate']);
-
-      /** temp logging */
-      this.logger.info("InteractionController: transformed reqDate: %o", reqDate)
-
       const createRequest = new InteractionCreateRequest(
         await new ParseIntPipe().transform(request.body['projectId'], null),
         request.body['stakeholder'],
-        reqDate,
+        request.body['communicationDate'],
         request.body['communicationDetails'],
         // Note, the generated api-client has little issue; it uses 'FormData' to append a file, but did not provide third
         // argument for 'filename'. To still use generated api-client, 'filename' could be found from extra formData property.
@@ -173,21 +162,11 @@ export class InteractionController {
       this.logger.info(`InteractionController: updating...`)
       this.logger.info(`InteractionController: request... %o`, request)
       this.logger.info("InteractionController: request.body['communicationDate']: %o", request.body['communicationDate'])
-
-      // const reqDate = _.isEmpty(request.body['communicationDate'])
-      //                 ? null
-      //                 : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
-      //                   DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
-
-      const reqDate = this.toLocalDate(request.body['communicationDate']);
-      
-      /** temp logging */
-      this.logger.info("InteractionController: transformed reqDate: %o", reqDate)
-                   
+             
       const updateRequest = new InteractionUpdateRequest(
         await new ParseIntPipe().transform(request.body['projectId'], null),
         request.body['stakeholder'],
-        reqDate,
+        request.body['communicationDate'],
         request.body['communicationDetails'],
         file?.originalname?.includes(".")? file.originalname: request.body['filename'],
         file? file.buffer: request.body['file']['buffer'],
@@ -214,18 +193,4 @@ export class InteractionController {
     await this.service.delete(id, user);
   }
 
-  private toLocalDate(dateString: string) {
-    // const reqDate = _.isEmpty(dateString)
-    //     ? null
-    //     : dayjs.tz(dayjs(dateString).utc(), 
-    //     DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
-    // return reqDate;
-    const reqDate = _.isEmpty(dateString)
-        ? null
-        : dayjs(dateString, DateTimeUtil.DATE_FORMAT, true).isValid()
-            ? dateString 
-            : dayjs.tz(dayjs(dateString).utc(), DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER)
-                .format(DateTimeUtil.DATE_FORMAT);
-    return reqDate;
-  }
 }

--- a/api/src/app/modules/interaction/interaction.controller.ts
+++ b/api/src/app/modules/interaction/interaction.controller.ts
@@ -118,10 +118,13 @@ export class InteractionController {
       this.logger.info(`InteractionController: request... %o`, request)
       this.logger.info("InteractionController: request.body['communicationDate']: %o", request.body['communicationDate'])
 
-      const reqDate = _.isEmpty(request.body['communicationDate'])
-                      ? null
-                      : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
-                        DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+    //   const reqDate = _.isEmpty(request.body['communicationDate'])
+    //                   ? null
+    //                   : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
+    //                     DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+    
+      const reqDate = this.toLocalDate(request.body['communicationDate']);
+
       /** temp logging */
       this.logger.info("InteractionController: transformed reqDate: %o", reqDate)
 
@@ -171,10 +174,13 @@ export class InteractionController {
       this.logger.info(`InteractionController: request... %o`, request)
       this.logger.info("InteractionController: request.body['communicationDate']: %o", request.body['communicationDate'])
 
-      const reqDate = _.isEmpty(request.body['communicationDate'])
-                      ? null
-                      : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
-                        DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+      // const reqDate = _.isEmpty(request.body['communicationDate'])
+      //                 ? null
+      //                 : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
+      //                   DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+
+      const reqDate = this.toLocalDate(request.body['communicationDate']);
+      
       /** temp logging */
       this.logger.info("InteractionController: transformed reqDate: %o", reqDate)
                    
@@ -208,4 +214,11 @@ export class InteractionController {
     await this.service.delete(id, user);
   }
 
+  private toLocalDate(dateString: string) {
+    const reqDate = _.isEmpty(dateString)
+        ? null
+        : dayjs.tz(dayjs(dateString).utc(), 
+        DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+    return reqDate;
+  }
 }

--- a/api/src/app/modules/interaction/interaction.controller.ts
+++ b/api/src/app/modules/interaction/interaction.controller.ts
@@ -113,10 +113,18 @@ export class InteractionController {
     @UserHeader() user: User,
     @UploadedFile('file') file: Express.Multer.File,
     @Req() request: fetch.Request): Promise<InteractionResponse> {
+      /** temp logging */
+      this.logger.info(`InteractionController: creating...`)
+      this.logger.info(`InteractionController: request...`, request)
+      this.logger.info("InteractionController: request.body['communicationDate']: ", request.body['communicationDate'])
+
       const reqDate = _.isEmpty(request.body['communicationDate'])
                       ? null
                       : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
                         DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+      /** temp logging */
+      this.logger.info("InteractionController: transformed reqDate: ", reqDate)
+
       const createRequest = new InteractionCreateRequest(
         await new ParseIntPipe().transform(request.body['projectId'], null),
         request.body['stakeholder'],
@@ -135,8 +143,6 @@ export class InteractionController {
         this.logger.debug('Create Interaction validation errors: %o', errMsgs);
         throw new BadRequestException(`Validation failed (${errMsgs})`);
       }
-      /** temp logging */
-      this.logger.info(`InteractionController: creating...`)
       return this.service.create(createRequest, user);
   }
 
@@ -160,10 +166,18 @@ export class InteractionController {
     @Param('id', ParseIntPipe) id: number,
     @UploadedFile('file') file: Express.Multer.File,
     @Req() request: fetch.Request): Promise<InteractionResponse> {
+      /** temp logging */
+      this.logger.info(`InteractionController: updating...`)
+      this.logger.info(`InteractionController: request...`, request)
+      this.logger.info("InteractionController: request.body['communicationDate']: ", request.body['communicationDate'])
+
       const reqDate = _.isEmpty(request.body['communicationDate'])
                       ? null
                       : dayjs.tz(dayjs(request.body['communicationDate']).utc(), 
-                        DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);                     
+                        DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+      /** temp logging */
+      this.logger.info("InteractionController: transformed reqDate: ", reqDate)
+                   
       const updateRequest = new InteractionUpdateRequest(
         await new ParseIntPipe().transform(request.body['projectId'], null),
         request.body['stakeholder'],
@@ -182,8 +196,6 @@ export class InteractionController {
         this.logger.debug('Update Interaction validation errors: %o', errMsgs);
         throw new BadRequestException(`Validation failed (${errMsgs})`);
       }
-      /** temp logging */
-      this.logger.info(`InteractionController: updating...`)
       return this.service.update(id, updateRequest, user);
   }
 

--- a/api/src/app/modules/interaction/interaction.controller.ts
+++ b/api/src/app/modules/interaction/interaction.controller.ts
@@ -135,6 +135,8 @@ export class InteractionController {
         this.logger.debug('Create Interaction validation errors: %o', errMsgs);
         throw new BadRequestException(`Validation failed (${errMsgs})`);
       }
+      /** temp logging */
+      this.logger.info(`InteractionController: creating...`)
       return this.service.create(createRequest, user);
   }
 
@@ -180,6 +182,8 @@ export class InteractionController {
         this.logger.debug('Update Interaction validation errors: %o', errMsgs);
         throw new BadRequestException(`Validation failed (${errMsgs})`);
       }
+      /** temp logging */
+      this.logger.info(`InteractionController: updating...`)
       return this.service.update(id, updateRequest, user);
   }
 

--- a/api/src/app/modules/interaction/interaction.controller.ts
+++ b/api/src/app/modules/interaction/interaction.controller.ts
@@ -112,11 +112,6 @@ export class InteractionController {
     @UserHeader() user: User,
     @UploadedFile('file') file: Express.Multer.File,
     @Req() request: fetch.Request): Promise<InteractionResponse> {
-      /** temp logging */
-      this.logger.info(`InteractionController: creating...`)
-      this.logger.info(`InteractionController: request... %o`, request)
-      this.logger.info("InteractionController: request.body['communicationDate']: %o", request.body['communicationDate'])
-
       const createRequest = new InteractionCreateRequest(
         await new ParseIntPipe().transform(request.body['projectId'], null),
         request.body['stakeholder'],
@@ -157,12 +152,7 @@ export class InteractionController {
     @UserHeader() user: User,
     @Param('id', ParseIntPipe) id: number,
     @UploadedFile('file') file: Express.Multer.File,
-    @Req() request: fetch.Request): Promise<InteractionResponse> {
-      /** temp logging */
-      this.logger.info(`InteractionController: updating...`)
-      this.logger.info(`InteractionController: request... %o`, request)
-      this.logger.info("InteractionController: request.body['communicationDate']: %o", request.body['communicationDate'])
-             
+    @Req() request: fetch.Request): Promise<InteractionResponse> {     
       const updateRequest = new InteractionUpdateRequest(
         await new ParseIntPipe().transform(request.body['projectId'], null),
         request.body['stakeholder'],

--- a/api/src/app/modules/interaction/interaction.controller.ts
+++ b/api/src/app/modules/interaction/interaction.controller.ts
@@ -215,10 +215,17 @@ export class InteractionController {
   }
 
   private toLocalDate(dateString: string) {
+    // const reqDate = _.isEmpty(dateString)
+    //     ? null
+    //     : dayjs.tz(dayjs(dateString).utc(), 
+    //     DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+    // return reqDate;
     const reqDate = _.isEmpty(dateString)
         ? null
-        : dayjs.tz(dayjs(dateString).utc(), 
-        DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER).format(DateTimeUtil.DATE_FORMAT);
+        : dayjs(dateString, DateTimeUtil.DATE_FORMAT, true).isValid()
+            ? dateString 
+            : dayjs.tz(dayjs(dateString).utc(), DateTimeUtil.DATE_FORMAT, DateTimeUtil.TIMEZONE_VANCOUVER)
+                .format(DateTimeUtil.DATE_FORMAT);
     return reqDate;
   }
 }

--- a/api/src/app/modules/interaction/interaction.dto.spec.ts
+++ b/api/src/app/modules/interaction/interaction.dto.spec.ts
@@ -23,6 +23,5 @@ describe('interaction.dto', () => {
         it (`Date string ${jsDateStringIsInvalid} is invalid for format ${DateTimeUtil.DATE_FORMAT} `, async () => {
             expect(isValidDateOnlyString(jsDateStringIsInvalid)).toBe(false);
         });
-
     })
 });

--- a/api/src/app/modules/interaction/interaction.dto.spec.ts
+++ b/api/src/app/modules/interaction/interaction.dto.spec.ts
@@ -1,0 +1,28 @@
+import { DateTimeUtil } from "@api-core/dateTimeUtil";
+import { isValidDateOnlyString } from "@api-modules/interaction/interaction.dto";
+
+describe('interaction.dto', () => {
+    describe('isValidDateOnlyString', () => {
+        const validTestDateStringValue = "2023-06-07";
+        const wrongStringArgument = "some-wrong-string";
+        const invalidFormatDateStringValue = "2003-06-07 03:30:45"; // should not have time.
+        const jsDateStringIsInvalid = "Sat Jun 03 2023 00:00:00 GMT-0700 (Pacific Daylight Time)"; // direct js Date() string should not match.
+
+        it (`Date string "${validTestDateStringValue}" is valid ${DateTimeUtil.DATE_FORMAT} string`, async () => {
+            expect(isValidDateOnlyString(validTestDateStringValue)).toBe(true);
+        });
+
+        it (`Date string ${wrongStringArgument} is invalid`, async () => {
+            expect(isValidDateOnlyString(wrongStringArgument)).toBe(false);
+        });
+
+        it (`Date string ${invalidFormatDateStringValue} is invalid for format ${DateTimeUtil.DATE_FORMAT} `, async () => {
+            expect(isValidDateOnlyString(invalidFormatDateStringValue)).toBe(false);
+        });
+
+        it (`Date string ${jsDateStringIsInvalid} is invalid for format ${DateTimeUtil.DATE_FORMAT} `, async () => {
+            expect(isValidDateOnlyString(jsDateStringIsInvalid)).toBe(false);
+        });
+
+    })
+});

--- a/api/src/app/modules/interaction/interaction.dto.spec.ts
+++ b/api/src/app/modules/interaction/interaction.dto.spec.ts
@@ -4,12 +4,17 @@ import { isValidDateOnlyString } from "@api-modules/interaction/interaction.dto"
 describe('interaction.dto', () => {
     describe('isValidDateOnlyString', () => {
         const validTestDateStringValue = "2023-06-07";
+        const wrongPatternDateStringValue = "06-07-2023";
         const wrongStringArgument = "some-wrong-string";
         const invalidFormatDateStringValue = "2003-06-07 03:30:45"; // should not have time.
         const jsDateStringIsInvalid = "Sat Jun 03 2023 00:00:00 GMT-0700 (Pacific Daylight Time)"; // direct js Date() string should not match.
 
         it (`Date string "${validTestDateStringValue}" is valid ${DateTimeUtil.DATE_FORMAT} string`, async () => {
             expect(isValidDateOnlyString(validTestDateStringValue)).toBe(true);
+        });
+
+        it (`Date string "${wrongPatternDateStringValue}" pattern not match ${DateTimeUtil.DATE_FORMAT}`, async () => {
+            expect(isValidDateOnlyString(wrongPatternDateStringValue)).toBe(false);
         });
 
         it (`Date string ${wrongStringArgument} is invalid`, async () => {

--- a/api/src/app/modules/interaction/interaction.dto.ts
+++ b/api/src/app/modules/interaction/interaction.dto.ts
@@ -14,6 +14,7 @@ export function IsISODateOnlyString(validationOptions?: ValidationOptions) {
             options: validationOptions,
             validator: {
               validate(value: any, _args: ValidationArguments) {
+                // validate if dto property value (such as 'communicationDate') passes date string format 'YYYY-MM-DD'
                 return !_.isEmpty(value) && dayjs(value, DateTimeUtil.DATE_FORMAT, true).isValid();
               },
             },

--- a/api/src/app/modules/interaction/interaction.dto.ts
+++ b/api/src/app/modules/interaction/interaction.dto.ts
@@ -15,11 +15,22 @@ export function IsISODateOnlyString(validationOptions?: ValidationOptions) {
             validator: {
               validate(value: any, _args: ValidationArguments) {
                 // validate if dto property value (such as 'communicationDate') passes date string format 'YYYY-MM-DD'
-                return !_.isEmpty(value) && dayjs(value, DateTimeUtil.DATE_FORMAT, true).isValid();
+                return isValidDateOnlyString(value);
               },
             },
         });
     }    
+}
+
+/*
+Limited to only check date string value with backend defined date format: DateTimeUtil.DATE_FORMAT.
+Valid date string like "2023-06-07" has length: 10 (so, no time portion).
+Note: "2023-06-07" and "06-07-2023" and "2023/06/07" etc are treated valid from dayjs library and all
+    are translated into "2023-06-07" by the dayjs library.
+For now it does not provide flexbility to check other format.
+*/
+export function isValidDateOnlyString(value: string): boolean {
+    return !_.isEmpty(value) && value.length == 10 && dayjs(value, DateTimeUtil.DATE_FORMAT, true).isValid();
 }
 
 export class InteractionCreateRequest {

--- a/api/src/app/modules/interaction/interaction.dto.ts
+++ b/api/src/app/modules/interaction/interaction.dto.ts
@@ -1,6 +1,25 @@
+import { DateTimeUtil } from '@api-core/dateTimeUtil';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsInt, IsNotEmpty, IsPositive, MaxLength, Min, MinLength } from 'class-validator';
+import { IsInt, IsNotEmpty, IsPositive, MaxLength, Min, MinLength, ValidationArguments, ValidationOptions, registerDecorator } from 'class-validator';
+import dayjs = require('dayjs');
 import _ = require('lodash');
+
+// Ref - class-validator: custom validator.
+export function IsISODateOnlyString(validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        registerDecorator({
+            name: 'isISODateOnlyString',
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            validator: {
+              validate(value: any, _args: ValidationArguments) {
+                return !_.isEmpty(value) && dayjs(value, DateTimeUtil.DATE_FORMAT, true).isValid();
+              },
+            },
+        });
+    }    
+}
 
 export class InteractionCreateRequest {
   constructor(projectId = null, 
@@ -26,7 +45,7 @@ export class InteractionCreateRequest {
   stakeholder: string;
 
   @ApiProperty({ required: true })
-  @IsDateString({}, {message: '"$property" must be ISO-formatted date.'})
+  @IsISODateOnlyString({message: `"$property" must be ISO-formatted date. (Required format: ${DateTimeUtil.DATE_FORMAT})`})
   @IsNotEmpty()
   communicationDate?: string;
 

--- a/api/src/app/modules/interaction/interaction.dto.ts
+++ b/api/src/app/modules/interaction/interaction.dto.ts
@@ -1,9 +1,9 @@
 import { DateTimeUtil } from '@api-core/dateTimeUtil';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsNotEmpty, IsPositive, MaxLength, Min, MinLength, ValidationArguments, ValidationOptions, registerDecorator } from 'class-validator';
+import * as customParseFormat from 'dayjs/plugin/customParseFormat';
 import dayjs = require('dayjs');
 import _ = require('lodash');
-import * as customParseFormat from 'dayjs/plugin/customParseFormat';
 
 // Ref - class-validator: custom validator.
 export function IsISODateOnlyString(validationOptions?: ValidationOptions) {

--- a/api/src/app/modules/interaction/interaction.dto.ts
+++ b/api/src/app/modules/interaction/interaction.dto.ts
@@ -3,6 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsNotEmpty, IsPositive, MaxLength, Min, MinLength, ValidationArguments, ValidationOptions, registerDecorator } from 'class-validator';
 import dayjs = require('dayjs');
 import _ = require('lodash');
+import * as customParseFormat from 'dayjs/plugin/customParseFormat';
 
 // Ref - class-validator: custom validator.
 export function IsISODateOnlyString(validationOptions?: ValidationOptions) {
@@ -30,6 +31,7 @@ Note: "2023-06-07" and "06-07-2023" and "2023/06/07" etc are treated valid from 
 For now it does not provide flexbility to check other format.
 */
 export function isValidDateOnlyString(value: string): boolean {
+    dayjs.extend(customParseFormat);
     return !_.isEmpty(value) && value.length == 10 && dayjs(value, DateTimeUtil.DATE_FORMAT, true).isValid();
 }
 

--- a/api/src/app/modules/interaction/interaction.service.ts
+++ b/api/src/app/modules/interaction/interaction.service.ts
@@ -96,19 +96,10 @@ export class InteractionService extends DataService<Interaction, Repository<Inte
 
   // basic fields validation is done using 'class-validator' on request dto, this is further business validation.
   private async businessValidate(request: InteractionCreateRequest | InteractionUpdateRequest) {
-    /** temp logging */
-    this.logger.info(`InteractionService-businessValidate, request: %o`, request);
-    this.logger.info(`InteractionService-businessValidate, communicationDate: %o`, request.communicationDate);
-
     // communication_date: >= commenting_open_date
     const project = await this.projectService.findOne(request.projectId);
     const commentingOpenDate = project.commentingOpenDate;
     const communicationDate = request.communicationDate;
-
-    /** temp logging */
-    this.logger.info(`InteractionService-businessValidate, commentingOpenDate: %o`, commentingOpenDate);
-    this.logger.info("InteractionService-businessValidate, startOf commentingOpenDate: %o", DateTimeUtil.getBcDate(commentingOpenDate).startOf('day'));
-    this.logger.info("InteractionService-businessValidate, startOf communicationDate: %o", DateTimeUtil.getBcDate(communicationDate).startOf('day'));
 
     if (DateTimeUtil.getBcDate(commentingOpenDate).startOf('day')
         .isAfter(DateTimeUtil.getBcDate(communicationDate).startOf('day'))) {

--- a/api/src/app/modules/interaction/interaction.service.ts
+++ b/api/src/app/modules/interaction/interaction.service.ts
@@ -97,7 +97,7 @@ export class InteractionService extends DataService<Interaction, Repository<Inte
   // basic fields validation is done using 'class-validator' on request dto, this is further business validation.
   private async businessValidate(request: InteractionCreateRequest | InteractionUpdateRequest) {
     /** temp logging */
-    this.logger.info(`InteractionService-businessValidate, request: ${request}`);
+    this.logger.info(`InteractionService-businessValidate, request:`, request);
     this.logger.info(`InteractionService-businessValidate, communicationDate: ${request.communicationDate}`);
 
     // communication_date: >= commenting_open_date

--- a/api/src/app/modules/interaction/interaction.service.ts
+++ b/api/src/app/modules/interaction/interaction.service.ts
@@ -97,8 +97,8 @@ export class InteractionService extends DataService<Interaction, Repository<Inte
   // basic fields validation is done using 'class-validator' on request dto, this is further business validation.
   private async businessValidate(request: InteractionCreateRequest | InteractionUpdateRequest) {
     /** temp logging */
-    this.logger.info(`InteractionService-businessValidate, request:`, request);
-    this.logger.info(`InteractionService-businessValidate, communicationDate: ${request.communicationDate}`);
+    this.logger.info(`InteractionService-businessValidate, request: %o`, request);
+    this.logger.info(`InteractionService-businessValidate, communicationDate: %o`, request.communicationDate);
 
     // communication_date: >= commenting_open_date
     const project = await this.projectService.findOne(request.projectId);
@@ -106,9 +106,9 @@ export class InteractionService extends DataService<Interaction, Repository<Inte
     const communicationDate = request.communicationDate;
 
     /** temp logging */
-    this.logger.info(`InteractionService-businessValidate, commentingOpenDate: ${commentingOpenDate}`);
-    this.logger.info(`InteractionService-businessValidate, startOf commentingOpenDate: ${DateTimeUtil.getBcDate(commentingOpenDate).startOf('day')}`);
-    this.logger.info(`InteractionService-businessValidate, startOf communicationDate: ${DateTimeUtil.getBcDate(communicationDate).startOf('day')}`);
+    this.logger.info(`InteractionService-businessValidate, commentingOpenDate: %o`, commentingOpenDate);
+    this.logger.info("InteractionService-businessValidate, startOf commentingOpenDate: %o", DateTimeUtil.getBcDate(commentingOpenDate).startOf('day'));
+    this.logger.info("InteractionService-businessValidate, startOf communicationDate: %o", DateTimeUtil.getBcDate(communicationDate).startOf('day'));
 
     if (DateTimeUtil.getBcDate(commentingOpenDate).startOf('day')
         .isAfter(DateTimeUtil.getBcDate(communicationDate).startOf('day'))) {

--- a/api/src/app/modules/interaction/interaction.service.ts
+++ b/api/src/app/modules/interaction/interaction.service.ts
@@ -96,11 +96,20 @@ export class InteractionService extends DataService<Interaction, Repository<Inte
 
   // basic fields validation is done using 'class-validator' on request dto, this is further business validation.
   private async businessValidate(request: InteractionCreateRequest | InteractionUpdateRequest) {
+    /** temp logging */
+    this.logger.info(`InteractionService-businessValidate, request: ${request}`);
+    this.logger.info(`InteractionService-businessValidate, communicationDate: ${request.communicationDate}`);
 
     // communication_date: >= commenting_open_date
     const project = await this.projectService.findOne(request.projectId);
     const commentingOpenDate = project.commentingOpenDate;
     const communicationDate = request.communicationDate;
+
+    /** temp logging */
+    this.logger.info(`InteractionService-businessValidate, commentingOpenDate: ${commentingOpenDate}`);
+    this.logger.info(`InteractionService-businessValidate, startOf commentingOpenDate: ${DateTimeUtil.getBcDate(commentingOpenDate).startOf('day')}`);
+    this.logger.info(`InteractionService-businessValidate, startOf communicationDate: ${DateTimeUtil.getBcDate(communicationDate).startOf('day')}`);
+
     if (DateTimeUtil.getBcDate(commentingOpenDate).startOf('day')
         .isAfter(DateTimeUtil.getBcDate(communicationDate).startOf('day'))) {
       throw new BadRequestException("Engagement Date should be on or after commenting start date.");


### PR DESCRIPTION
This PR contains few fix for #371 .

- Restrict datePicker no earlier than commenting start date on Stakeholder Engagement.
   To prevent confusion on selecting Stakeholder communication date (frontend) earlier than the (backend) rule:
"Engagement Date should be on or after commenting start date." I added a "minDate" for datePicker so user can't picker date earlier than that date.

- Fix frontend to pass date string consistently as "YYYY-MM-DD".
- Refine backend controller/dto to enforce "communication date" validation through custom class-validator and make sure date string in request is a valid "YYYY-MM-DD".
- Also test/verify date parsing validation works through out the day and particularly date selected on the commenting start date is allowed.
---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-370.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-370.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-370.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-370.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-370.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-370.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)