### PR TITLE
bug: add deploy prereq in main merge

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -109,7 +109,7 @@ jobs:
 
   deploy-prod:
     name: PROD Deploys
-    needs: [codeql]
+    needs: [codeql, deploy-test]
     environment: prod
     env:
       ZONE: prod


### PR DESCRIPTION
It's possible to deploy to PROD before TEST in the unlikely case environment access is approved before TEST deploy completes.

Medium priority bug for edge case.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-376.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-376.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-376.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)