### PR TITLE
Fix/353 get file content sec access

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -27,6 +27,7 @@
         "@rxweb/reactive-form-validators": "~13.0.0",
         "aws-amplify": "^5.1.4",
         "bootstrap": "~5.2.0",
+        "file-saver": "^2.0.5",
         "jquery": "^3.6.0",
         "leaflet": "~1.9.0",
         "leaflet.markercluster": "~1.5.3",
@@ -18865,6 +18866,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -26,6 +26,7 @@
     "@rxweb/reactive-form-validators": "~13.0.0",
     "aws-amplify": "^5.1.4",
     "bootstrap": "~5.2.0",
+    "file-saver": "^2.0.5",
     "jquery": "^3.6.0",
     "leaflet": "~1.9.0",
     "leaflet.markercluster": "~1.5.3",

--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.html
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.html
@@ -196,10 +196,10 @@
             <div class="doc-list row"
                   *ngFor="let attachment of attachmentsInitialNotice">
                 <a class="doc-list__item"
-                    style="width: 90%;"
-                    [href]="attachmentResolverSvc.getAttachmentUrl(attachment.id)"
+                    style="width: 90%;cursor:pointer"
+                    (click)="attachmentResolverSvc.getFileContents(attachment.id, attachment.fileName)"
                     [title]="attachment.fileName || ''"
-                    target="_blank" rel="noopener">
+                    rel="noopener">
                   <div class="cell doc-list__item-icon">
                     <em class="material-icons">
                       insert_drive_file
@@ -249,10 +249,10 @@
               <div class="doc-list row"
                  *ngFor="let attachment of attachments">
                 <a class="doc-list__item"
-                    style="width: 90%;"
-                    [href]="attachmentResolverSvc.getAttachmentUrl(attachment.id)"
+                    style="width: 90%;cursor:pointer"
+                    (click)="attachmentResolverSvc.getFileContents(attachment.id, attachment.fileName)"
                     [title]="attachment.fileName || ''"
-                    target="_blank" rel="noopener">
+                    rel="noopener">
                   <div class="cell doc-list__item-icon">
                     <em class="material-icons">
                       insert_drive_file

--- a/admin/src/app/foms/fom-detail/fom-detail.component.html
+++ b/admin/src/app/foms/fom-detail/fom-detail.component.html
@@ -123,8 +123,10 @@
                 <h2>Attachments</h2>
                 <section *ngIf="attachments.length > 0">
                  <div class="doc-list row" *ngFor="let attachment of attachments">
+                    <!-- <button (click)="attachmentResolverSvc.getFileContents(attachment.id)">Downlad</button> -->
                     <a class="doc-list__item" style="width: 90%;"
-                       [href]="attachmentResolverSvc.getAttachmentUrl(attachment.id)"
+                        href="#"
+                       (click)="attachmentResolverSvc.getFileContents(attachment.id)"
                        [title]="attachment.fileName || ''"
                        target="_blank" rel="noopener">
                       <div class="cell doc-list__item-icon">
@@ -135,6 +137,19 @@
                       <div class="cell doc-list__item-name">{{attachment.fileName}}</div>
                       <div style="text-align: right;margin-right: 5px;">({{attachment.attachmentType.description}})</div>
                     </a>
+
+                    <!-- <a class="doc-list__item" style="width: 90%;"
+                       (click)="attachmentResolverSvc.getFileContents(attachment.id)"
+                       [title]="attachment.fileName || ''"
+                       target="_blank" rel="noopener">
+                      <div class="cell doc-list__item-icon">
+                        <em class="material-icons">
+                           insert_drive_file
+                        </em>
+                      </div>
+                      <div class="cell doc-list__item-name">{{attachment.fileName}}</div>
+                      <div style="text-align: right;margin-right: 5px;">({{attachment.attachmentType.description}})</div>
+                    </a> -->
                     <button *ngIf="isDeleteAttachmentAllowed(attachment)" class="btn btn-icon row doc-list__item" 
                             title="Delete this attachment"
                             (click)="deleteAttachment(attachment.id)"

--- a/admin/src/app/foms/fom-detail/fom-detail.component.html
+++ b/admin/src/app/foms/fom-detail/fom-detail.component.html
@@ -124,8 +124,7 @@
                 <section *ngIf="attachments.length > 0">
                  <div class="doc-list row" *ngFor="let attachment of attachments">
                     <!-- <button (click)="attachmentResolverSvc.getFileContents(attachment.id)">Downlad</button> -->
-                    <a class="doc-list__item" style="width: 90%;"
-                        href="#"
+                    <a class="doc-list__item" style="width: 90%;cursor:pointer"
                        (click)="attachmentResolverSvc.getFileContents(attachment.id)"
                        [title]="attachment.fileName || ''"
                        target="_blank" rel="noopener">

--- a/admin/src/app/foms/fom-detail/fom-detail.component.html
+++ b/admin/src/app/foms/fom-detail/fom-detail.component.html
@@ -125,7 +125,7 @@
                  <div class="doc-list row" *ngFor="let attachment of attachments">
                     <!-- <button (click)="attachmentResolverSvc.getFileContents(attachment.id)">Downlad</button> -->
                     <a class="doc-list__item" style="width: 90%;cursor:pointer"
-                       (click)="attachmentResolverSvc.getFileContents(attachment.id)"
+                       (click)="attachmentResolverSvc.getFileContents(attachment.id, attachment.fileName)"
                        [title]="attachment.fileName || ''"
                        target="_blank" rel="noopener">
                       <div class="cell doc-list__item-icon">

--- a/admin/src/app/foms/fom-detail/fom-detail.component.html
+++ b/admin/src/app/foms/fom-detail/fom-detail.component.html
@@ -126,7 +126,7 @@
                     <a class="doc-list__item" style="width: 90%;cursor:pointer"
                        (click)="attachmentResolverSvc.getFileContents(attachment.id, attachment.fileName)"
                        [title]="attachment.fileName || ''"
-                       target="_blank" rel="noopener">
+                       rel="noopener">
                       <div class="cell doc-list__item-icon">
                         <em class="material-icons">
                            insert_drive_file

--- a/admin/src/app/foms/fom-detail/fom-detail.component.html
+++ b/admin/src/app/foms/fom-detail/fom-detail.component.html
@@ -123,7 +123,6 @@
                 <h2>Attachments</h2>
                 <section *ngIf="attachments.length > 0">
                  <div class="doc-list row" *ngFor="let attachment of attachments">
-                    <!-- <button (click)="attachmentResolverSvc.getFileContents(attachment.id)">Downlad</button> -->
                     <a class="doc-list__item" style="width: 90%;cursor:pointer"
                        (click)="attachmentResolverSvc.getFileContents(attachment.id, attachment.fileName)"
                        [title]="attachment.fileName || ''"
@@ -136,19 +135,6 @@
                       <div class="cell doc-list__item-name">{{attachment.fileName}}</div>
                       <div style="text-align: right;margin-right: 5px;">({{attachment.attachmentType.description}})</div>
                     </a>
-
-                    <!-- <a class="doc-list__item" style="width: 90%;"
-                       (click)="attachmentResolverSvc.getFileContents(attachment.id)"
-                       [title]="attachment.fileName || ''"
-                       target="_blank" rel="noopener">
-                      <div class="cell doc-list__item-icon">
-                        <em class="material-icons">
-                           insert_drive_file
-                        </em>
-                      </div>
-                      <div class="cell doc-list__item-name">{{attachment.fileName}}</div>
-                      <div style="text-align: right;margin-right: 5px;">({{attachment.attachmentType.description}})</div>
-                    </a> -->
                     <button *ngIf="isDeleteAttachmentAllowed(attachment)" class="btn btn-icon row doc-list__item" 
                             title="Delete this attachment"
                             (click)="deleteAttachment(attachment.id)"

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
@@ -95,7 +95,7 @@
       <label for="upload">Attachment</label>
       <a class="doc-list__item"
           style="cursor:pointer"
-          (click)="attachmentSvc.attachmentControllerGetFileContents(attachment.id)"
+          (click)="attachmentResolverSvc.getFileContents(attachment.id, attachment.fileName)"
           [title]="attachment.fileName || ''"
           rel="noopener">
         <div class="cell doc-list__item-icon">

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
@@ -94,7 +94,7 @@
           *ngIf="attachment">
       <label for="upload">Attachment</label>
       <a class="doc-list__item"
-          [href]="getAttachmentUrl(attachment.id)"
+          (click)="attachmentSvc.attachmentControllerGetFileContents(attachment.id)"
           [title]="attachment.fileName || ''"
           target="_blank" rel="noopener">
         <div class="cell doc-list__item-icon">

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.html
@@ -94,9 +94,10 @@
           *ngIf="attachment">
       <label for="upload">Attachment</label>
       <a class="doc-list__item"
+          style="cursor:pointer"
           (click)="attachmentSvc.attachmentControllerGetFileContents(attachment.id)"
           [title]="attachment.fileName || ''"
-          target="_blank" rel="noopener">
+          rel="noopener">
         <div class="cell doc-list__item-icon">
           <em class="material-icons">
               insert_drive_file

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
@@ -7,6 +7,7 @@ import { ConfigService } from '@utility/services/config.service';
 import { InteractionDetailForm, InteractionRequest } from './interaction-detail.form';
 
 import { UploadBoxComponent } from '@admin-core/components/file-upload-box/file-upload-box.component';
+import { AttachmentResolverSvc } from '@admin-core/services/AttachmentResolverSvc';
 import { DatePipe, NgClass, NgIf } from '@angular/common';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 
@@ -55,7 +56,8 @@ export class InteractionDetailComponent {
   constructor(
     private formBuilder: RxFormBuilder,
     private configSvc: ConfigService,
-    public attachmentSvc: AttachmentService
+    public attachmentSvc: AttachmentService,
+    public attachmentResolverSvc: AttachmentResolverSvc,
   ) { }
 
   @Input() set selectedInteraction(interaction: InteractionResponse) {

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
@@ -55,7 +55,7 @@ export class InteractionDetailComponent {
   constructor(
     private formBuilder: RxFormBuilder,
     private configSvc: ConfigService,
-    private attachmentSvc: AttachmentService
+    public attachmentSvc: AttachmentService
   ) { }
 
   @Input() set selectedInteraction(interaction: InteractionResponse) {

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
@@ -94,10 +94,6 @@ export class InteractionDetailComponent {
                       .attachmentControllerFindOne(attachmentId).toPromise();
   }
 
-  getAttachmentUrl(id: number): string {
-    return this.configSvc.getAttachmentUrl(id);
-  }
-
   isValid(controlName: string): boolean {
     return this.interactionFormGroup.controls[controlName]?.errors == null;
   }

--- a/admin/src/app/foms/summary/interactions-summary/interactions-summary.component.html
+++ b/admin/src/app/foms/summary/interactions-summary/interactions-summary.component.html
@@ -48,9 +48,11 @@
       <div class="col-md-2 bold">Attachment: </div>
       <div class="col-md-10">
         <a id="attachment-link"
-          [href]="getAttachmentUrl(interaction?.attachmentId)" 
+          *ngIf="interaction.attachmentId"
+          style="cursor:pointer"
+          (click)="attachmentResolverSvc.getFileContents(interaction?.attachmentId, interaction?.fileName)" 
           [title]="interaction?.fileName || ''" 
-          target="_blank" rel="noopener">
+          rel="noopener">
           {{interaction?.fileName}}
         </a>
       </div>

--- a/admin/src/app/foms/summary/interactions-summary/interactions-summary.component.ts
+++ b/admin/src/app/foms/summary/interactions-summary/interactions-summary.component.ts
@@ -4,7 +4,8 @@ import { InteractionResponse } from '@api-client';
 import { ConfigService } from '@utility/services/config.service';
 
 import { NewlinesPipe } from '@admin-core/pipes/newlines.pipe';
-import { DatePipe, NgFor, NgStyle, NgTemplateOutlet } from '@angular/common';
+import { AttachmentResolverSvc } from '@admin-core/services/AttachmentResolverSvc';
+import { DatePipe, NgFor, NgIf, NgStyle, NgTemplateOutlet } from '@angular/common';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -12,6 +13,7 @@ import { MatIconModule } from '@angular/material/icon';
 @Component({
     standalone: true,
     imports: [
+        NgIf,
         MatExpansionModule, 
         NgStyle, 
         MatIconModule, 
@@ -36,7 +38,10 @@ export class InteractionsSummaryComponent implements OnInit {
   @ViewChild(MatAccordion) 
   accordion: MatAccordion;
   
-  constructor(private configSvc: ConfigService) { }
+  constructor(
+    private configSvc: ConfigService,
+    public attachmentResolverSvc: AttachmentResolverSvc
+  ) { }
 
   ngOnInit(): void {
     // Deliberately empty
@@ -46,7 +51,4 @@ export class InteractionsSummaryComponent implements OnInit {
     this.interactions = interactions;
   }
 
-  getAttachmentUrl(id: number): string {
-    return this.configSvc.getAttachmentUrl(id);
-  }
 }

--- a/admin/src/app/foms/summary/summary.component.html
+++ b/admin/src/app/foms/summary/summary.component.html
@@ -131,9 +131,10 @@
                   </td>
                   <td data-label="File Name">
                     <a id="attachment-link"
-                      [href]="getAttachmentUrl(attachment.id)"
+                      style="cursor:pointer"
+                      (click)="attachmentResolverSvc.getFileContents(attachment.id, attachment.fileName)"
                       [title]="attachment.fileName || ''"
-                      target="_blank" rel="noopener">
+                      rel="noopener">
                       {{attachment.fileName}}
                     </a>
                   </td>

--- a/admin/src/app/foms/summary/summary.component.ts
+++ b/admin/src/app/foms/summary/summary.component.ts
@@ -20,6 +20,7 @@ import { DetailsMapComponent } from '../details-map/details-map.component';
 import { ShapeInfoComponent } from '../shape-info/shape-info.component';
 import { CommentsSummaryComponent } from './comments-summary/comments-summary.component';
 import { InteractionsSummaryComponent } from './interactions-summary/interactions-summary.component';
+import { AttachmentResolverSvc } from '@admin-core/services/AttachmentResolverSvc';
 
 @Component({
     standalone: true,
@@ -70,7 +71,8 @@ export class SummaryComponent implements OnInit, OnDestroy {
     private spatialFeatureSvc: SpatialFeatureService,
     private interactionSvc: InteractionService,
     private attachmentSvc: AttachmentService,
-    private configSvc: ConfigService
+    private configSvc: ConfigService,
+    public attachmentResolverSvc: AttachmentResolverSvc
   ) { }
 
   async ngOnInit(): Promise<void> {
@@ -84,10 +86,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
     this.scopeOptionChange$.pipe(takeUntil(this.ngUnsubscribe$)).subscribe((nextScope) => {
       this.doFiltering(nextScope);
     });
-  }
-
-  getAttachmentUrl(id: number): string {
-    return this.configSvc.getAttachmentUrl(id);
   }
 
   private async getProject(projectId: number) {

--- a/admin/src/core/services/AttachmentResolverSvc.ts
+++ b/admin/src/core/services/AttachmentResolverSvc.ts
@@ -1,12 +1,10 @@
 import { AttachmentTypeEnum } from "@admin-core/models/attachmentTypeEnum";
-import { HttpResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import {
     AttachmentResponse,
     AttachmentService,
     WorkflowStateEnum,
 } from '@api-client';
-import { ConfigService } from "@utility/services/config.service";
 import { saveAs } from "file-saver";
 
 @Injectable({
@@ -15,9 +13,7 @@ import { saveAs } from "file-saver";
 export class AttachmentResolverSvc {
 
   constructor(
-    public attachmentService: AttachmentService,
-    private configSvc: ConfigService
-
+    public attachmentService: AttachmentService
   ) {  }
 
   public async getAttachments(projectId: number): Promise<AttachmentResponse[]> {
@@ -38,10 +34,6 @@ export class AttachmentResolverSvc {
               // file-saver:saveAs will download the file.
               saveAs(data, filename);
         });
-  }
-
-  getAttachmentUrl(id: number): string {
-    return this.configSvc.getAttachmentUrl(id);
   }
 
   /**

--- a/admin/src/core/services/AttachmentResolverSvc.ts
+++ b/admin/src/core/services/AttachmentResolverSvc.ts
@@ -28,12 +28,12 @@ export class AttachmentResolverSvc {
     return this.attachmentService.attachmentControllerRemove(attachmentId).toPromise();
   }
 
+  // Used for (click) event from <a>/<button> at Angular page to download a file.
   public async getFileContents(fileId: number, filename: string): Promise<void> {
     this.attachmentService.attachmentControllerGetFileContents(fileId)
-        .subscribe((res: HttpResponse<Blob>) => {
-            console.log("res: ", res)
-            const data: Blob = new Blob([res.body], {
-                type: res.body.type
+        .subscribe((value: Blob) => {
+            const data: Blob = new Blob([value], {
+                type: value.type
               });
               // file-saver:saveAs will download the file.
               saveAs(data, filename);

--- a/admin/src/core/services/AttachmentResolverSvc.ts
+++ b/admin/src/core/services/AttachmentResolverSvc.ts
@@ -1,11 +1,12 @@
 import { AttachmentTypeEnum } from "@admin-core/models/attachmentTypeEnum";
-import {Injectable} from "@angular/core";
+import { HttpResponse } from "@angular/common/http";
+import { Injectable } from "@angular/core";
 import {
-  AttachmentService,
-  AttachmentResponse,
-  WorkflowStateEnum,
+    AttachmentResponse,
+    AttachmentService,
+    WorkflowStateEnum,
 } from '@api-client';
-import {ConfigService} from "@utility/services/config.service";
+import { ConfigService } from "@utility/services/config.service";
 import { saveAs } from "file-saver";
 
 @Injectable({
@@ -29,11 +30,12 @@ export class AttachmentResolverSvc {
 
   public async getFileContents(fileId: number, filename: string): Promise<void> {
     this.attachmentService.attachmentControllerGetFileContents(fileId)
-        .subscribe((res) => {
+        .subscribe((res: HttpResponse<Blob>) => {
             console.log("res: ", res)
-            const data: Blob = new Blob([res], {
-                type: res.type
+            const data: Blob = new Blob([res.body], {
+                type: res.body.type
               });
+              // file-saver:saveAs will download the file.
               saveAs(data, filename);
         });
   }

--- a/admin/src/core/services/AttachmentResolverSvc.ts
+++ b/admin/src/core/services/AttachmentResolverSvc.ts
@@ -26,8 +26,11 @@ export class AttachmentResolverSvc {
     return this.attachmentService.attachmentControllerRemove(attachmentId).toPromise();
   }
 
-  public async getFileContents(fileId: number): Promise<any> {
-    return this.attachmentService.attachmentControllerGetFileContents(fileId).toPromise();
+  public async getFileContents(fileId: number): Promise<void> {
+    this.attachmentService.attachmentControllerGetFileContents(fileId)
+        .subscribe((res) => {
+            console.log("res: ", res)
+        })
   }
 
   getAttachmentUrl(id: number): string {

--- a/admin/src/core/services/AttachmentResolverSvc.ts
+++ b/admin/src/core/services/AttachmentResolverSvc.ts
@@ -6,6 +6,7 @@ import {
   WorkflowStateEnum,
 } from '@api-client';
 import {ConfigService} from "@utility/services/config.service";
+import { saveAs } from "file-saver";
 
 @Injectable({
   providedIn: 'root'
@@ -26,11 +27,15 @@ export class AttachmentResolverSvc {
     return this.attachmentService.attachmentControllerRemove(attachmentId).toPromise();
   }
 
-  public async getFileContents(fileId: number): Promise<void> {
+  public async getFileContents(fileId: number, filename: string): Promise<void> {
     this.attachmentService.attachmentControllerGetFileContents(fileId)
         .subscribe((res) => {
             console.log("res: ", res)
-        })
+            const data: Blob = new Blob([res], {
+                type: res.type
+              });
+              saveAs(data, filename);
+        });
   }
 
   getAttachmentUrl(id: number): string {

--- a/admin/src/core/services/AttachmentResolverSvc.ts
+++ b/admin/src/core/services/AttachmentResolverSvc.ts
@@ -26,6 +26,10 @@ export class AttachmentResolverSvc {
     return this.attachmentService.attachmentControllerRemove(attachmentId).toPromise();
   }
 
+  public async getFileContents(fileId: number): Promise<any> {
+    return this.attachmentService.attachmentControllerGetFileContents(fileId).toPromise();
+  }
+
   getAttachmentUrl(id: number): string {
     return this.configSvc.getAttachmentUrl(id);
   }

--- a/api/openapi/swagger-spec.json
+++ b/api/openapi/swagger-spec.json
@@ -114,7 +114,15 @@
           ],
           "responses": {
             "200": {
-              "description": ""
+              "description": "",
+              "content": {
+                "application/octet-stream": {
+                  "schema": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
             }
           },
           "tags": [

--- a/api/src/app/modules/attachment/attachment.controller.ts
+++ b/api/src/app/modules/attachment/attachment.controller.ts
@@ -75,16 +75,13 @@ export class AttachmentController {
     return this.service.create(createRequest, user);
   }
 
-	@ApiResponse({
-		schema: {
-			type: 'string',
-			format: 'binary',
-		},
-		status: HttpStatus.OK,
-	})
+	@ApiProduces('application/octet-stream')
   @Get('/file/:id')
   @ApiBearerAuth()
-  @ApiOkResponse() 
+  @ApiOkResponse({	schema: {
+			type: 'string',
+			format: 'binary',
+		}}) 
   async getFileContents(
     @UserHeader() user: User,
     @Param('id', ParseIntPipe) id: number,

--- a/api/src/app/modules/attachment/attachment.controller.ts
+++ b/api/src/app/modules/attachment/attachment.controller.ts
@@ -75,9 +75,10 @@ export class AttachmentController {
     return this.service.create(createRequest, user);
   }
 
-	@ApiProduces('application/octet-stream')
+  @ApiProduces('application/octet-stream')
   @Get('/file/:id')
   @ApiBearerAuth()
+  @AuthGuardMeta(GUARD_OPTIONS.ANONYMOUS_LIMITED)
   @ApiOkResponse({	schema: {
 			type: 'string',
 			format: 'binary',

--- a/api/src/app/modules/attachment/attachment.controller.ts
+++ b/api/src/app/modules/attachment/attachment.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Post, Delete, Param, HttpStatus, Query, UseInterceptors, UploadedFile, Req, Request, Res, ParseIntPipe, BadRequestException, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOkResponse, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOkResponse, ApiProduces, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Express } from 'express';
 import { Multer } from 'multer'; // This is needed, don't know why Visual Studio Code thinks it isn't.
 
@@ -75,10 +75,15 @@ export class AttachmentController {
     return this.service.create(createRequest, user);
   }
 
+	@ApiResponse({
+		schema: {
+			type: 'string',
+			format: 'binary',
+		},
+		status: HttpStatus.OK,
+	})
   @Get('/file/:id')
   @ApiBearerAuth()
-  // TODO: This should have same security level the same as isViewAuthorized().
-  // Frontend: should pass header (from admin), currently it does not. Api service should check with isViewAuthorized().
   @ApiOkResponse() 
   async getFileContents(
     @UserHeader() user: User,

--- a/api/src/app/modules/attachment/attachment.service.ts
+++ b/api/src/app/modules/attachment/attachment.service.ts
@@ -92,14 +92,15 @@ export class AttachmentService extends DataService<Attachment, Repository<Attach
   }
 
   async isDeleteAuthorized(entity: Attachment, user?: User):Promise<boolean> {
+    const attachmentTypeCode = entity.attachmentType?.code;
     // for Interaction.
-    if (entity.attachmentTypeCode == AttachmentTypeEnum.INTERACTION) {
+    if (attachmentTypeCode == AttachmentTypeEnum.INTERACTION) {
       return this.projectAuthService.isForestClientUserAllowedStateAccess(entity.projectId, 
         [WorkflowStateEnum.COMMENT_OPEN, WorkflowStateEnum.COMMENT_CLOSED], user);
     }
 
     // for public notice; public notice can't be deleted but can be replaced after initial state.
-    if (entity.attachmentTypeCode == AttachmentTypeEnum.PUBLIC_NOTICE) {
+    if (attachmentTypeCode == AttachmentTypeEnum.PUBLIC_NOTICE) {
       return this.projectAuthService.isForestClientUserAllowedStateAccess(entity.projectId, 
         [WorkflowStateEnum.INITIAL], user);
     }
@@ -111,8 +112,9 @@ export class AttachmentService extends DataService<Attachment, Repository<Attach
 
   async isViewAuthorized(entity: Attachment, user?: User): Promise<boolean> {
     console.log("Attachment entity:", entity)
-    console.log("entity.attachmentTypeCode:", entity.attachmentTypeCode)
-    if (entity.attachmentTypeCode == AttachmentTypeEnum.PUBLIC_NOTICE || entity.attachmentTypeCode == AttachmentTypeEnum.SUPPORTING_DOC) {
+    const attachmentTypeCode = entity.attachmentType?.code;
+    console.log("attachmentTypeCode:", attachmentTypeCode)
+    if (attachmentTypeCode == AttachmentTypeEnum.PUBLIC_NOTICE || attachmentTypeCode == AttachmentTypeEnum.SUPPORTING_DOC) {
       // These document types are viewable by the public.
       return true;
     }

--- a/api/src/app/modules/attachment/attachment.service.ts
+++ b/api/src/app/modules/attachment/attachment.service.ts
@@ -141,7 +141,6 @@ export class AttachmentService extends DataService<Attachment, Repository<Attach
   }
 
   async getFileContent(id: number, user?: User): Promise<AttachmentFileResponse> {
-
     const attachmentFileResponse = await this.findFileDatabase(id, user);
 
     //Creating the objectName for the Object Storage
@@ -165,8 +164,9 @@ export class AttachmentService extends DataService<Attachment, Repository<Attach
     // NestJS/TypeORM has breaking change for find API which only accespts 'option' argument and
     // no 'id' for findOne(id, options) like before. We need to specifically build the 'options.where'
     // for the TypeORM api now.
-    const revisedOptions = this.addCommonRelationsToFindOptions(this.addCommonRelationsToFindOptions(
-        { select: [ 'id', 'projectId', 'fileName', 'attachmentType' ] }));
+    const revisedOptions = this.addCommonRelationsToFindOptions(
+        { select: [ 'id', 'projectId', 'fileName', 'attachmentType']}
+    );
     revisedOptions.where = { ...revisedOptions.where, id } as unknown as FindOptionsWhere<Attachment>;
     const entity:Attachment = await this.repository.findOne(revisedOptions);
 

--- a/api/src/app/modules/attachment/attachment.service.ts
+++ b/api/src/app/modules/attachment/attachment.service.ts
@@ -111,9 +111,7 @@ export class AttachmentService extends DataService<Attachment, Repository<Attach
   }
 
   async isViewAuthorized(entity: Attachment, user?: User): Promise<boolean> {
-    console.log("Attachment entity:", entity)
     const attachmentTypeCode = entity.attachmentType?.code;
-    console.log("attachmentTypeCode:", attachmentTypeCode)
     if (attachmentTypeCode == AttachmentTypeEnum.PUBLIC_NOTICE || attachmentTypeCode == AttachmentTypeEnum.SUPPORTING_DOC) {
       // These document types are viewable by the public.
       return true;

--- a/api/src/app/modules/attachment/attachment.service.ts
+++ b/api/src/app/modules/attachment/attachment.service.ts
@@ -110,7 +110,8 @@ export class AttachmentService extends DataService<Attachment, Repository<Attach
   }
 
   async isViewAuthorized(entity: Attachment, user?: User): Promise<boolean> {
-
+    console.log("Attachment entity:", entity)
+    console.log("entity.attachmentTypeCode:", entity.attachmentTypeCode)
     if (entity.attachmentTypeCode == AttachmentTypeEnum.PUBLIC_NOTICE || entity.attachmentTypeCode == AttachmentTypeEnum.SUPPORTING_DOC) {
       // These document types are viewable by the public.
       return true;

--- a/api/src/app/modules/interaction/interaction.service.ts
+++ b/api/src/app/modules/interaction/interaction.service.ts
@@ -56,7 +56,7 @@ export class InteractionService extends DataService<Interaction, Repository<Inte
       }
       const prviousAttachmentId = entity.attachmentId;
       if (prviousAttachmentId) {
-        const updateCount = (await super.updateEntity(id, {attachmentId: undefined}, entity)).affected; // remove previous attachment from Interaction first.
+        const updateCount = (await super.updateEntity(id, {attachmentId: null}, entity)).affected; // remove previous attachment from Interaction first.
         if (updateCount != 1) {
           throw new InternalServerErrorException("Error removing previous attachment");
         }

--- a/api/src/app/modules/project/project-auth.service.ts
+++ b/api/src/app/modules/project/project-auth.service.ts
@@ -28,7 +28,6 @@ export class ProjectAuthService {
    async isForestClientUserAccess(projectId: number, user?: User): Promise<boolean> {
 
     if (!user?.isForestClient) {
-      console.log(`!user?.isForestClient: ${!user?.isForestClient}`)
       return false;
     }
 

--- a/libs/client/typescript-ng/api/attachment.service.ts
+++ b/libs/client/typescript-ng/api/attachment.service.ts
@@ -290,10 +290,10 @@ export class AttachmentService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public attachmentControllerGetFileContents(id: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined}): Observable<any>;
-    public attachmentControllerGetFileContents(id: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined}): Observable<HttpResponse<any>>;
-    public attachmentControllerGetFileContents(id: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: undefined}): Observable<HttpEvent<any>>;
-    public attachmentControllerGetFileContents(id: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: undefined}): Observable<any> {
+    public attachmentControllerGetFileContents(id: number, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream'}): Observable<Blob>;
+    public attachmentControllerGetFileContents(id: number, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream'}): Observable<HttpResponse<Blob>>;
+    public attachmentControllerGetFileContents(id: number, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/octet-stream'}): Observable<HttpEvent<Blob>>;
+    public attachmentControllerGetFileContents(id: number, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/octet-stream'}): Observable<any> {
         if (id === null || id === undefined) {
             throw new Error('Required parameter id was null or undefined when calling attachmentControllerGetFileContents.');
         }
@@ -311,6 +311,7 @@ export class AttachmentService {
         if (httpHeaderAcceptSelected === undefined) {
             // to determine the Accept header
             const httpHeaderAccepts: string[] = [
+                'application/octet-stream'
             ];
             httpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
         }
@@ -319,14 +320,9 @@ export class AttachmentService {
         }
 
 
-        let responseType: 'text' | 'json' = 'json';
-        if(httpHeaderAcceptSelected && httpHeaderAcceptSelected.startsWith('text')) {
-            responseType = 'text';
-        }
-
-        return this.httpClient.get<any>(`${this.configuration.basePath}/api/attachment/file/${encodeURIComponent(String(id))}`,
+        return this.httpClient.get(`${this.configuration.basePath}/api/attachment/file/${encodeURIComponent(String(id))}`,
             {
-                responseType: <any>responseType,
+                responseType: "blob",
                 withCredentials: this.configuration.withCredentials,
                 headers: headers,
                 observe: observe,

--- a/public/package-lock.json
+++ b/public/package-lock.json
@@ -25,6 +25,7 @@
         "@ng-bootstrap/ng-bootstrap": "^14.0.0",
         "@rxweb/reactive-form-validators": "~13.0.0",
         "bootstrap": "~5.2.0",
+        "file-saver": "^2.0.5",
         "jquery": "^3.6.0",
         "leaflet": "~1.9.0",
         "leaflet.markercluster": "~1.5.3",
@@ -9215,6 +9216,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",

--- a/public/package.json
+++ b/public/package.json
@@ -24,6 +24,7 @@
     "@ng-bootstrap/ng-bootstrap": "^14.0.0",
     "@rxweb/reactive-form-validators": "~13.0.0",
     "bootstrap": "~5.2.0",
+    "file-saver": "^2.0.5",
     "jquery": "^3.6.0",
     "leaflet": "~1.9.0",
     "leaflet.markercluster": "~1.5.3",
@@ -55,8 +56,8 @@
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "eslint": "^8.23.0",
-    "jest-preset-angular": "^13.0.0",
     "jest": "^29.5.0",
+    "jest-preset-angular": "^13.0.0",
     "ts-jest": "^29.1.0",
     "ts-node": "~9.1.1",
     "typescript": "^4.8.0"

--- a/public/src/app/applications/details-panel/details-panel.component.html
+++ b/public/src/app/applications/details-panel/details-panel.component.html
@@ -108,9 +108,10 @@
         <div class="doc-list" style="width: 25rem;">
           <a class="doc-list__item"
             *ngFor="let attachment of attachments"
-            [href]="configService.getAttachmentUrl(attachment.id)" 
+            style="cursor:pointer"
+            (click)="getFileContents(attachment.id, attachment.fileName)"
             [title]="attachment.fileName || ''" 
-            target="_blank" rel="noopener">
+            rel="noopener">
             <div class="cell doc-list__item-icon">
               <em class="material-icons">
                 <!-- insert_drive_file -->

--- a/public/src/app/applications/details-panel/details-panel.component.ts
+++ b/public/src/app/applications/details-panel/details-panel.component.ts
@@ -10,6 +10,7 @@ import { ConfigService } from '@utility/services/config.service';
 import { FeatureSelectService } from '@utility/services/featureSelect.service';
 import { DetailsMapComponent } from 'app/applications/details-panel/details-map/details-map.component';
 import { ShapeInfoComponent } from 'app/applications/details-panel/shape-info/shape-info.component';
+import { saveAs } from "file-saver";
 import * as _ from 'lodash';
 import { Subject, forkJoin } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
@@ -177,6 +178,18 @@ export class DetailsPanelComponent implements OnDestroy, OnInit {
         }
       });
   }
+
+  // Used for (click) event from <a>/<button> at Angular page to download a file.
+  public async getFileContents(fileId: number, filename: string): Promise<void> {
+    this.attachmentService.attachmentControllerGetFileContents(fileId)
+        .subscribe((value: Blob) => {
+            const data: Blob = new Blob([value], {
+                type: value.type
+                });
+                // file-saver:saveAs will download the file.
+                saveAs(data, filename);
+        });
+    }
 
   /**
    * On component destroy.


### PR DESCRIPTION
This PR is for #353. The fixes include:
- Use `GUARD_OPTIONS.ANONYMOUS_LIMITED` security for Attachment.controller.ts `getFileContents` endpoint.
- Add swagger @ApiProduces('application/octet-stream') for response type.
- Fix bug in `isViewAuthorized` due to Attachment entity not returning attachmentTypeCode.
- Generate new api-client for frontend.
- Use convenient lib `file-saver` for handling downloaded file for public/admin frontend.
- Fix previous download attachment using <a> direct link by replacing it with (click) event and call api backend with proper user header.
- Adjust backend attachment service `findFileDatabase` entity loading options based on discussion.
- Fix Interaction attachment update issue from calling TypeORM repository.update() function due to TypeORM behavior change.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-381.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-381.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-381.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-381.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-381.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-381.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)