### PR TITLE
Chore: #210 - Adjust Readme Example Command for Generating Migration Template.

### DIFF
--- a/api/src/migrations/README.md
+++ b/api/src/migrations/README.md
@@ -8,8 +8,7 @@ Migration scripts are written in javascript (.js) and not typescript deliberatel
 On build, migration scripts are treated similar to assets and copied into the dist directory.
 On execution, the migration config (in ormconfig-migration-{main|test}.ts loads migration directories for both the source working tree and for the dist setup.
 
-### To create a new migration
-
-- npm run typeorm migration:create -- -o -f ./src/migrations/ormconfig-migration-{test|main}.ts -n {name}
-(Need to ensure a .js javascript migration is created, not a .ts typescript, to run migrations at startup).
+### To create a new migration empty template
+- npm run typeorm migration:create -- -o ./src/migrations/{main|test}/{name-of-new-migration-file}
+  ( -o option: Need to ensure a .js javascript migration is created, not a .ts typescript, to run migrations at startup).
 


### PR DESCRIPTION
Readme sample command for "Migrations" for "api" does not reflect the new upgraded TypeORM cli command change. Adjust it so we can still use it to generate a template.
* This only reflects 'option' change from "migration:create": "-n" and "-f" aren't right options anymore. Direct use destination <path/file-name> to generate new template. 
* This does not affect main/test "real" migrations. Still works for new TypeORM upgrade.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-386.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-386.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-386.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)