### PR TITLE
Fix NestJS watch mode loop endlessly for Windows.

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -26,5 +26,8 @@
       "@api-modules/*": ["src/app/modules/*"],
       "@utility/*": ["../libs/utility/src/*"]
     }
+  },
+  "watchOptions": {
+    "watchFile": "fixedPollingInterval"
   }
 }


### PR DESCRIPTION
The problem exists for Windows and for certain combination of NestJs and Typescript (version 4.9 and up) versions can experience this problem. (This did not happen before merging of @nestjs/cli ~9.5.0)
NestJS provides a possible solution on official site (https://docs.nestjs.com/faq/common-errors) to use this option in tsconfig.
The fix should not affect mac devices.
https://docs.nestjs.com/faq/common-errors

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-412.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-412.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-412.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)