### PR TITLE
Fix:/ #210 Feedback on Early Public Notice Publishing Date

### DIFF
--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
@@ -71,7 +71,7 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
   public attachments: AttachmentResponse[] = [];
   public attachmentsInitialNotice: AttachmentResponse[] = [];
   public isDeleting = false;
-  public minOpeningDate: Date = new Date();
+  public minOpeningDate: Date = moment(moment().format('YYYY-MM-DD')).add(1, 'days').toDate(); // 1 day in the future.
   public minClosedDate: Date;
   public fileTypesParentInitial: string[] =
     ['image/png', 'image/jpeg', 'image/jpg', 'image/tiff',

--- a/admin/src/app/foms/fom-detail/fom-detail.component.html
+++ b/admin/src/app/foms/fom-detail/fom-detail.component.html
@@ -117,6 +117,10 @@
                         {{project.publicNoticeId? 'Yes' : 'No'}}
                       </span>
                     </li>
+                    <li *ngIf="project.publicNoticeId">
+                        <span class="name">Notice Publishing Date:</span>
+                        <span class="value">{{project.noticePostDate}}</span>
+                    </li>
                   </ul>
                 </section>
                 <br />

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.html
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.html
@@ -70,7 +70,7 @@
                 [minDate]="minPostDate"
                 [maxDate]="maxPostDate"
                 (keydown)="$event.preventDefault()"
-                (click)="isPostDateSelectionAvailable(postDatePicker)"
+                (click)="warnIfPostDateSelectionNotAvailable(postDatePicker)"
                 id="post-date"
                 name="pn-post-date"
                 formControlName="pnPostDate"

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.ts
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.ts
@@ -119,11 +119,13 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
       // So, specifically set it here. In this tricky case: commentingOpenDate=1 day in future from today => 
       // maxDate = minDate for datePicker. (which means notice publishing date can only have 1 choice: minPostDate) 
       const pnPostDate = this.publicNoticeResponse?.postDate
-      if (pnPostDate 
-          && moment(this.minPostDate).isSameOrBefore(this.maxPostDate)
-          && (moment(pnPostDate).isBefore(moment(this.minPostDate)) || moment(pnPostDate).isAfter(this.maxPostDate))
-      ) {
+      if (pnPostDate && moment(this.minPostDate).isSameOrBefore(this.maxPostDate)) {
+        if (moment(pnPostDate).isBefore(moment(this.minPostDate)) || moment(pnPostDate).isAfter(this.maxPostDate)){
           this.publicNoticeResponse.postDate = moment(this.minPostDate).format('YYYY-MM-DD');
+        }
+      }
+      else if (pnPostDate && moment(this.project.commentingOpenDate).isBefore(moment(this.minPostDate))) {
+        this.publicNoticeResponse.postDate = null;
       }
     }
   }
@@ -220,6 +222,9 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
 
     if (body.pnPostDate) {
       body.postDate = this.datePipe.transform(body.pnPostDate,'yyyy-MM-dd');
+    }
+    else {
+      body.postDate = null;
     }
     if (this.isAddNewNotice()) {
       return this.publicNoticeService.publicNoticeControllerCreate(body);

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.ts
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.ts
@@ -116,15 +116,14 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
     else { // a case there was public notice saved for the project.
       // This is a tricky case. "bsDatepicker" when (minDate=maxDate) and when previous field date falls
       // outside of the date range, "bsDatepicker" has problem initializing it and even if you trying picking from UI.
-      // So, specifically set it here. In this tricky case: commentingOpenDate=1 day in future from today => 
-      // maxDate = minDate for datePicker. (which means notice publishing date can only have 1 choice: minPostDate) 
+      // So, specifically set it here for corner cases.
       const pnPostDate = this.publicNoticeResponse?.postDate
-      if (pnPostDate && moment(this.minPostDate).isSameOrBefore(this.maxPostDate)) {
+      if (pnPostDate && moment(this.minPostDate).isSameOrBefore(moment(this.project.commentingOpenDate))) {
         if (moment(pnPostDate).isBefore(moment(this.minPostDate)) || moment(pnPostDate).isAfter(this.maxPostDate)){
           this.publicNoticeResponse.postDate = moment(this.minPostDate).format('YYYY-MM-DD');
         }
       }
-      else if (pnPostDate && moment(this.project.commentingOpenDate).isBefore(moment(this.minPostDate))) {
+      else if (pnPostDate && moment(this.minPostDate).isAfter(moment(this.project.commentingOpenDate))) {
         this.publicNoticeResponse.postDate = null;
       }
     }
@@ -234,11 +233,13 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
     }
   }
 
-  isPostDateSelectionAvailable(postDatePicker) {
-    if (!this.project.commentingOpenDate) {
-        postDatePicker.toggle(); // bsDatepicker seems to have strange behaviour. hide() won't work, use toggle() instead.
-        this.modalSvc.openWarningDialog(`Commenting Start Date must be entered first before 
-        Public Notice Publishing Date is available for selection.`);
+  warnIfPostDateSelectionNotAvailable(postDatePicker) {
+    if (!this.project.commentingOpenDate ||
+      moment(this.minPostDate).isAfter(moment(this.project.commentingOpenDate))
+    ) {
+      postDatePicker.toggle(); // bsDatepicker seems to have strange behaviour. hide() won't work, use toggle() instead.
+      this.modalSvc.openWarningDialog(`Commenting Start Date must be entered first or at least one day in the future before 
+        Notice Publishing Date is available for selection.`);
     }
   }
 

--- a/admin/src/app/foms/public-notice/public-notice.form.ts
+++ b/admin/src/app/foms/public-notice/public-notice.form.ts
@@ -55,8 +55,8 @@ export class PublicNoticeForm {
   email: string;
 
   @minDate({
-    value: moment().add(1, 'days').format('YYYY-MM-DD'), 
-    message: 'Must post notice one day in the future'})
+    value: moment().add(1, 'days').format('YYYY-MM-DD'),
+    message: 'Must publish notice one day in the future'})
   @prop()
   pnPostDate: Date;
   

--- a/api/openapi/swagger-spec.json
+++ b/api/openapi/swagger-spec.json
@@ -1831,6 +1831,9 @@
             "publicNoticeId": {
               "type": "number"
             },
+            "noticePostDate": {
+              "type": "string"
+            },
             "operationStartYear": {
               "type": "number"
             },
@@ -1853,6 +1856,7 @@
             "createTimestamp",
             "commentClassificationMandatory",
             "publicNoticeId",
+            "noticePostDate",
             "operationStartYear",
             "operationEndYear"
           ]
@@ -2047,8 +2051,8 @@
               "type": "string"
             },
             "postDate": {
-                "type": "string",
-                "description": "Date planed for online public notice posted."
+              "type": "string",
+              "description": "Date planed for online public notice posted."
             },
             "project": {
               "$ref": "#/components/schemas/ProjectResponse"
@@ -2095,8 +2099,8 @@
               "type": "string"
             },
             "postDate": {
-                "type": "string",
-                "description": "Date planed for online public notice posted."
+              "type": "string",
+              "description": "Date planed for online public notice posted."
             },
             "revisionCount": {
               "type": "number"
@@ -2191,8 +2195,8 @@
               "type": "string"
             },
             "postDate": {
-                "type": "string",
-                "description": "Date planed for online public notice posted."
+              "type": "string",
+              "description": "Date planed for online public notice posted."
             },
             "revisionCount": {
               "type": "number"
@@ -2609,4 +2613,4 @@
         }
       }
     }
-}
+  }

--- a/api/src/app/modules/project/project.dto.ts
+++ b/api/src/app/modules/project/project.dto.ts
@@ -139,6 +139,9 @@ export class ProjectResponse {
   @ApiProperty()
   publicNoticeId: number; // Online Public Notice (if any)
 
+  @ApiProperty()
+  noticePostDate: string;
+
   @ApiProperty({ required: true })
   operationStartYear: number;
 

--- a/api/src/app/modules/project/project.dto.ts
+++ b/api/src/app/modules/project/project.dto.ts
@@ -140,7 +140,7 @@ export class ProjectResponse {
   publicNoticeId: number; // Online Public Notice (if any)
 
   @ApiProperty()
-  noticePostDate: string;
+  noticePostDate?: string;
 
   @ApiProperty({ required: true })
   operationStartYear: number;

--- a/api/src/app/modules/project/project.service.ts
+++ b/api/src/app/modules/project/project.service.ts
@@ -227,6 +227,7 @@ export class ProjectService extends DataService<Project, Repository<Project>, Pr
     response.commentClassificationMandatory = entity.commentClassificationMandatory;
     if (entity.publicNotices && entity.publicNotices.length > 0) {
       response.publicNoticeId = entity.publicNotices[0].id; // Currently one public notice for a project.
+      response.noticePostDate = entity.publicNotices[0].postDate;
     }
     response.operationStartYear = entity.operationStartYear;
     response.operationEndYear = entity.operationEndYear;

--- a/api/src/app/modules/project/project.service.ts
+++ b/api/src/app/modules/project/project.service.ts
@@ -526,7 +526,7 @@ export class ProjectService extends DataService<Project, Repository<Project>, Pr
 					const dayDiff = DateTimeUtil.diffNow(postDate, DateTimeUtil.TIMEZONE_VANCOUVER, 'day');
 					if (dayDiff < 1) {
 							throw new BadRequestException(`Unable to transition FOM ${entity.id} to ${stateTransition}.  
-							Online Public Notice Publish Date: must be at least one day after publish is pushed.`);
+							Online Public Notice Publish Date: must be at least one day in the future.`);
 					}
         }
       }

--- a/libs/client/typescript-ng/model/projectResponse.ts
+++ b/libs/client/typescript-ng/model/projectResponse.ts
@@ -41,6 +41,7 @@ export interface ProjectResponse {
     createTimestamp: string;
     commentClassificationMandatory: boolean;
     publicNoticeId: number;
+    noticePostDate: string;
     operationStartYear: number;
     operationEndYear: number;
 }


### PR DESCRIPTION
Feedback adjustment for #210 from Julius.
- FOM add/edit page, restrict date-picker for minDate in one day in the future.
- Add displaying Notice Publishing Date information on FOM detail page in detail block.
- Adjust logic for Notice Publishing Date date-picker warning popup when selection is not available.
- Fix edit public notice page for public notice publishing date date-picker corner cases that when previous date entered falls outside of date-picker range and when date-picker minDate/maxDate are the same or not valid.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-422.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-422.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-422.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)