### PR TITLE
fix:#426 Notice publish date warning and adjustment disable date picker manual input

### DIFF
--- a/admin/src/app/foms/fom-detail/enddate-change-modal/enddate-change-modal.component.html
+++ b/admin/src/app/foms/fom-detail/enddate-change-modal/enddate-change-modal.component.html
@@ -37,6 +37,7 @@
               bsDatepicker
               [bsValue]="minDate"
               [minDate]="minDate"
+              (keydown)="$event.preventDefault()"
               [(ngModel)]="newCommentingClosedDate"
               #nccdDatepicker="bsDatepicker"
               id="newCommentingClosedDate"

--- a/admin/src/app/foms/public-notice/public-notice-edit.component.ts
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.ts
@@ -238,7 +238,7 @@ export class PublicNoticeEditComponent implements OnInit, OnDestroy {
       moment(this.minPostDate).isAfter(moment(this.project.commentingOpenDate))
     ) {
       postDatePicker.toggle(); // bsDatepicker seems to have strange behaviour. hide() won't work, use toggle() instead.
-      this.modalSvc.openWarningDialog(`Commenting Start Date must be entered first or at least one day in the future before 
+      this.modalSvc.openWarningDialog(`Commenting Start Date must be entered first and at least one day in the future before 
         Notice Publishing Date is available for selection.`);
     }
   }


### PR DESCRIPTION
This is for ticket #426 .
Quick adjustment on warning text and disable for user manual input on date-picker (change end date page).

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-431.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-431.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-431.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)