### PR TITLE
fix: Caddy upgrade for security warnings

### DIFF
--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -2,7 +2,6 @@
 ARG build_dir=public
 ARG port=4300
 
-
 # Build container
 FROM node:18.16.1-alpine3.17 AS build
 
@@ -17,7 +16,7 @@ RUN cd libs && npm ci && cd .. && \
 
 
 # Deploy container
-FROM caddy:2.4.6-alpine
+FROM caddy:2.6.4-alpine
 
 # Copy over Caddyfile and static content
 ARG build_dir

--- a/public/openshift.deploy.yml
+++ b/public/openshift.deploy.yml
@@ -109,6 +109,9 @@ objects:
         spec:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-${COMPONENT}
+              securityContext:
+                capabilities:
+                  add: ["NET_BIND_SERVICE"]
               imagePullPolicy: Always
               name: ${NAME}
               env:


### PR DESCRIPTION
Pretty much a copy of https://github.com/bcgov/nr-fom/pull/452, but for public.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-456.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-456.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-456.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)