### PR TITLE
fix: #454 Increase email field maxlength to 100

### DIFF
--- a/admin/src/app/foms/public-notice/public-notice-edit.component.html
+++ b/admin/src/app/foms/public-notice/public-notice-edit.component.html
@@ -195,11 +195,11 @@
       </div>
 
       <div class="row" >
-        <div class="form-group col-md-6">
+        <div class="form-group col-md-12">
           <label for="email" [ngClass]="{'required': editMode}">Email for Public Comment</label>
           <input type="text"
             id="email" name="email"
-            maxlength="50"
+            maxlength="100"
             [placeholder]="editMode? 'name@industry.com': ''"
             class="form-control"
             formControlName="email"/>

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.html
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.html
@@ -172,7 +172,7 @@
 
       <div class="row">
         <div class="col-sm-4 bold">Email for Public Comment: </div>
-        <div class="col-sm-8">{{pn.email}}</div>
+        <div class="col-sm-8 word-wrap">{{pn.email}}</div>
       </div>
 
       <div class="validity-txt" *ngIf="pn.operationStartYear && pn.operationEndYear">

--- a/public/src/assets/styles/layout/layout.scss
+++ b/public/src/assets/styles/layout/layout.scss
@@ -134,3 +134,7 @@ hr {
 .form-group {
   margin-bottom: 1rem
 }
+
+.word-wrap {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Ticket #464 - Increase online public notice "email" input field.
* admin: Input maxlength="100".
* public: use "word-wrap" class for display very long email.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-466.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-466.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-466.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)