### PR TITLE
fix: #465 - Remove init-cap formatting from FOM name

### DIFF
--- a/admin/src/app/foms/fom-detail/fom-detail.component.html
+++ b/admin/src/app/foms/fom-detail/fom-detail.component.html
@@ -79,7 +79,7 @@
                 <section>
                   <h2>Name</h2>
                   <p class="mb-0"
-                     [innerHTML]="project.name ? (project.name | titlecase) : '<em>No applicant on this file</em>'"></p>
+                     [innerHTML]="project.name ? project.name : '<em>No applicant on this file</em>'"></p>
                 </section>
                 <section>
                   <h2>Description</h2>

--- a/admin/src/app/foms/summary/summary.component.html
+++ b/admin/src/app/foms/summary/summary.component.html
@@ -31,7 +31,7 @@
         <section class="project-info">
           <div>
             <h4>Name</h4>
-            {{project?.name | titlecase}}
+            {{project?.name}}
           </div>
 
           <div>

--- a/admin/src/app/search/search.component.html
+++ b/admin/src/app/search/search.component.html
@@ -112,7 +112,7 @@
                 <strong>{{project.id }}</strong>
               </td>
               <td
-                [innerHTML]="project.name ? (project.name | titlecase) : '<em>No FOM name on this File</em>'">
+                [innerHTML]="project.name ? project.name : '<em>No FOM name on this File</em>'">
               </td>
               <td>
                 {{project.fspId}}


### PR DESCRIPTION
This PR is for ticket: #465
- Remove frontend 'titlecase' Angular pipe so the html page will display as what user entered and not first letter cap (TSL TA0893 => “Tsl Ta0893”).