### PR TITLE
fix: #493 Mouse Zoom Without Click 

### DIFF
--- a/admin/src/app/foms/details-map/details-map.component.ts
+++ b/admin/src/app/foms/details-map/details-map.component.ts
@@ -98,8 +98,7 @@ export class DetailsMapComponent implements OnInit, OnChanges, OnDestroy {
     this.map = L.map('map', {
       layers: mapLayers.getAllLayers(),
       zoomControl: false, // will be added manually below
-      attributionControl: true, 
-      scrollWheelZoom: false, // not desired in thumbnail
+      attributionControl: true,
       doubleClickZoom: false, // not desired in thumbnail
       zoomSnap: 0.1, // for greater granularity when fitting bounds
       zoomDelta: 1, 
@@ -108,7 +107,6 @@ export class DetailsMapComponent implements OnInit, OnChanges, OnDestroy {
       maxBounds: L.latLngBounds(L.latLng(-90, -180), L.latLng(90, 180)) // restrict view to "the world"
     });
 
-    this.map.on('click', () => { this.map.scrollWheelZoom.enable(); });
     this.map.on('blur', () => { this.map.scrollWheelZoom.disable(); });
     
     mapLayers.addLayerControl(this.map);

--- a/api/README.md
+++ b/api/README.md
@@ -79,3 +79,4 @@ These are the steps to generate the client library used by the frontend componen
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+    

--- a/public/src/app/applications/details-panel/details-map/details-map.component.ts
+++ b/public/src/app/applications/details-panel/details-map/details-map.component.ts
@@ -100,8 +100,7 @@ export class DetailsMapComponent implements OnInit, OnChanges, OnDestroy {
     this.map = L.map('map', {
       layers: this.mapLayers.getAllLayers(),
       zoomControl: false, // will be added manually below
-      attributionControl: true, 
-      scrollWheelZoom: false, // not desired in thumbnail
+      attributionControl: true,
       doubleClickZoom: false, // not desired in thumbnail
       zoomSnap: 0.1, // for greater granularity when fitting bounds
       zoomDelta: 1, 
@@ -123,8 +122,7 @@ export class DetailsMapComponent implements OnInit, OnChanges, OnDestroy {
     this.map.on('overlayremove', (e: L.LayersControlEvent) => {
       this.mapLayersService.notifyLayersChange({overlay: {action: OverlayAction.Remove, layerName: e.name}});
     });
-
-    this.map.on('click', () => { this.map.scrollWheelZoom.enable(); });
+    
     this.map.on('blur', () => { this.map.scrollWheelZoom.disable(); });
 
     // Initialize current app-map layers state (for the first time when this component map is shown)


### PR DESCRIPTION
Default behavior change to: No need to click on map to enable zooming. Once mouse pointer lands on map (give it a < 1 second), user can then scroll and zoom in/out without needing to click on map.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-49.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-49.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-49.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)