### PR TITLE
fix: #491 Detail Bookmark Link Not Accessible

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -78,5 +78,5 @@ These are the steps to generate the client library used by the frontend componen
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
-    limitations under the License.
+    limitations under the License. 
     

--- a/public/src/app/applications/details-panel/details-panel.component.ts
+++ b/public/src/app/applications/details-panel/details-panel.component.ts
@@ -72,7 +72,7 @@ export class DetailsPanelComponent implements OnDestroy, OnInit {
     // Works if user has bookmarks the detail link.
     this.getProjectDetails();
 
-    // Subscribe to onNavEnd so the component knoews subsequent clicks on other details.
+    // Subscribe to onNavEnd so the component knows subsequent clicks on other details.
     this.urlService.onNavEnd$.pipe(takeUntil(this.ngUnsubscribe))
         .subscribe(() => {
           this.getProjectDetails();

--- a/public/src/app/applications/details-panel/details-panel.component.ts
+++ b/public/src/app/applications/details-panel/details-panel.component.ts
@@ -70,16 +70,12 @@ export class DetailsPanelComponent implements OnDestroy, OnInit {
     // First time component init. The `urlService.onNavEnd$` already ends, so 
     // do this initially first since queryParam is ready from route. 
     // Works if user has bookmarks the detail link.
-    this.loadQueryParameters();
-    if (this.projectIdFilter.filter.value) {
-      this.getProjectDetails();
-    }
+    this.getProjectDetails();
 
-    // Subscribe eariler before event onNavEnd.
+    // Subscribe to onNavEnd so the component knoews subsequent clicks on other details.
     this.urlService.onNavEnd$.pipe(takeUntil(this.ngUnsubscribe))
         .subscribe(() => {
-            this.loadQueryParameters();
-            this.getProjectDetails();
+          this.getProjectDetails();
         });
 
     this.subscribeToFeatureSelectChange();
@@ -90,7 +86,14 @@ export class DetailsPanelComponent implements OnDestroy, OnInit {
    * @memberof DetailsPanelComponent
    */
   public getProjectDetails() {
+    this.loadQueryParameters();
     const projectId = parseInt(this.projectIdFilter.filter.value);
+    if (!projectId) {
+      // no project to display
+      this.project = null;
+      return;
+    }
+
     this.isAppLoading = true;
     forkJoin({
       project: this.projectService.projectControllerFindOne(projectId),


### PR DESCRIPTION
Allow user's bookmark on "Public" FOM detail to be accessible when clicked.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-32.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-32.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-32.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)