### PR TITLE
ci: trivy bump and param rename

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,13 +46,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.16.0
+        uses: aquasecurity/trivy-action@0.16.1
         with:
           format: "sarif"
           output: "trivy-results.sarif"
           ignore-unfixed: true
           scan-type: "fs"
-          security-checks: "vuln,secret,config"
+          scanners: "vuln,secret,config"
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Bump Trivy to 16.1 and rename a parameter, which changed upstream.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-37.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-37.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-37.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)