### PR TITLE
fix: #557 Configure CLIENT API Token For DEMO

### DIFF
--- a/.github/workflows/merge-demo.yml
+++ b/.github/workflows/merge-demo.yml
@@ -69,6 +69,7 @@ jobs:
               -p DB_TESTDATA=true
               -p AWS_USER_POOLS_WEB_CLIENT_ID="k3b9ip1vf85o4tkqvu5g4adgj"
               -p LOGOUT_CHAIN_URL="https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+              -p BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME="fom-demo-client-app-api"
           - name: admin
             file: admin/openshift.deploy.yml
             overwrite: true

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -76,6 +76,9 @@ parameters:
     description: FAM Authentication Cognito logout chain url for Siteminder and Keycloak
     value: "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
     required: true
+  - name: BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME
+    description: OP secrete name for CLIENT API Token.
+    value: "fom-client-app-api"
 objects:
   - apiVersion: v1
     kind: ImageStream
@@ -214,12 +217,12 @@ objects:
                   valueFrom:
                     secretKeyRef:
                       key: api_base_url
-                      name: fom-client-app-api
+                      name: ${BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME}
                 - name: CLIENT_API_TOKEN
                   valueFrom:
                     secretKeyRef:
                       key: api_token
-                      name: fom-client-app-api
+                      name: ${BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME}
               ports:
                 - containerPort: ${{PORT}}
                   protocol: TCP
@@ -422,12 +425,12 @@ objects:
                       valueFrom:
                         secretKeyRef:
                           key: api_base_url
-                          name: fom-client-app-api
+                          name: ${BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME}
                     - name: CLIENT_API_TOKEN
                       valueFrom:
                         secretKeyRef:
                           key: api_token
-                          name: fom-client-app-api
+                          name: ${BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME}
                   resources:
                     requests:
                       cpu: ${CPU_REQUEST}


### PR DESCRIPTION
Configuring "**DEMO**" deployment to use CLIENT "**PROD**" for batch data refreshing.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-8.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-8.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-8.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)