### PR TITLE
fix(ci): cronjob namespaces

### DIFF
--- a/.github/workflows/merge-demo.yml
+++ b/.github/workflows/merge-demo.yml
@@ -55,7 +55,7 @@ jobs:
             file: api/openshift.deploy.yml
             overwrite: true
             parameters:
-              -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
+              -p OC_NAMESPACE=a4b31c-test
               -p URL=fom-demo.apps.silver.devops.gov.bc.ca
               -p FOM_EMAIL_NOTIFY=FLNR.AdminServicesCariboo@gov.bc.ca
               -p DB_TESTDATA=true

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -55,7 +55,7 @@ jobs:
             file: api/openshift.deploy.yml
             overwrite: true
             parameters:
-              -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
+              -p OC_NAMESPACE=a4b31c-test
               -p URL=fom-test.nrs.gov.bc.ca
               -p FOM_EMAIL_NOTIFY=FLNR.AdminServicesCariboo@gov.bc.ca
               -p DB_TESTDATA=true
@@ -121,7 +121,7 @@ jobs:
             file: api/openshift.deploy.yml
             overwrite: true
             parameters:
-              -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
+              -p OC_NAMESPACE=a4b31c-prod
               -p URL=fom.nrs.gov.bc.ca
               -p AWS_USER_POOLS_WEB_CLIENT_ID="4bu2n8at3m32a2fqnvd4t06la1"
               -p LOGOUT_CHAIN_URL="https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="


### PR DESCRIPTION
TEST cronjobs were running with images from the DEV namespace.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-24.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-24.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-24.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)