### PR TITLE
chore(ci): block Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
   "extends": [
     "github>bcgov/renovate-config"
   ],
+  "automerge": false,
   "prConcurrentLimit": 3
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,13 @@
   "extends": [
     "github>bcgov/renovate-config"
   ],
-  "automerge": false,
-  "prConcurrentLimit": 3
+  "prConcurrentLimit": 3,
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
To prevent accidentally letting Renovate automerge PRs here's a rule change.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-30.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-30.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-30.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)