### PR TITLE
chore(ci): exclude minio from renovate (for now)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,12 @@
         "*"
       ],
       "automerge": false
+    },
+    {
+      "excludeDepNames": [
+        "minio"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Updating minio seems to be causing problems.  This is intended to block it from Renovate updates.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-40.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-40.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-40.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)