### PR TITLE
fix: #611 bcgw extract ocp route timeout

### DIFF
--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -290,6 +290,8 @@ objects:
         app: ${NAME}-${ZONE}
         certbot-managed: ${CERTBOT}
       name: ${NAME}-${ZONE}-${COMPONENT}
+      annotations:
+        haproxy.router.openshift.io/timeout: 90s # (Fix 611 - /bcgw-extract long time response in prod)
     spec:
       host: ${URL}
       path: /${COMPONENT}

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -291,7 +291,7 @@ objects:
         certbot-managed: ${CERTBOT}
       name: ${NAME}-${ZONE}-${COMPONENT}
       annotations:
-        haproxy.router.openshift.io/timeout: 90s # (Fix 611 - /bcgw-extract long time response in prod)
+        haproxy.router.openshift.io/timeout: 120s # (Fix 611 - /bcgw-extract long time response in prod)
     spec:
       host: ${URL}
       path: /${COMPONENT}

--- a/api/src/app/modules/spatial-feature/spatial-feature.controller.ts
+++ b/api/src/app/modules/spatial-feature/spatial-feature.controller.ts
@@ -4,6 +4,7 @@ import { PinoLogger } from 'nestjs-pino';
 
 import { SpatialFeatureBcgwResponse, SpatialFeaturePublicResponse } from './spatial-feature.dto';
 import { SpatialFeatureService } from './spatial-feature.service';
+import { performance } from 'perf_hooks';
 
 @ApiTags('spatial-feature')
 @Controller('spatial-feature')
@@ -31,9 +32,15 @@ export class SpatialFeatureController {
       throw new BadRequestException('Invalid version');
     }
 
-    this.logger.debug('Start get /spatial-feature/bcgw-extract'); // For measuring performance.
-  
-    return this.spatialFeatureService.getBcgwExtract();
+    this.logger.info('Start get /spatial-feature/bcgw-extract'); // For measuring performance.
+
+    const start = performance.now();
+    const result = this.spatialFeatureService.getBcgwExtract();
+    const end = performance.now();
+
+    this.logger.info(`End get /spatial-feature/bcgw-extract for ${end - start}ms.`);
+
+    return result;
   }
 
 }


### PR DESCRIPTION
BCGW encountered timeout when calling "/bcgw-extract" endpoint.
Basil found out the function is taking more time in prod resulting to ocp router timeout (default 30s).
A better performance fix will be on other ticket.
For this fix we:
- Address timeout issue on router for immediate prod operation fix.
- Add info log for function's performance to benefit for troubleshooting in future. 

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-13.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-13.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-13.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-13.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-13.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-13.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)