### PR TITLE
Increase production api memeory request/limit and adjust 1 hour early…

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -89,6 +89,8 @@ jobs:
               -p URL=fom.nrs.gov.bc.ca
               -p AWS_USER_POOLS_WEB_CLIENT_ID="4bu2n8at3m32a2fqnvd4t06la1"
               -p LOGOUT_CHAIN_URL="https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+              -p MEMORY_REQUEST=650Mi
+              -p MEMORY_LIMIT=2Gi
             post_rollout: oc create job "certbot-manual-$(date +%s)" --from=cronjob/certbot
           - name: admin
             file: admin/openshift.deploy.yml

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -42,6 +42,8 @@ parameters:
     value: 30m
   - name: MEMORY_REQUEST
     value: 150Mi
+  - name: MEMORY_LIMIT
+    value: 1Gi
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
@@ -230,6 +232,8 @@ objects:
                 - containerPort: ${{PORT}}
                   protocol: TCP
               resources:
+                limits:
+                  memory: ${MEMORY_LIMIT}
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
@@ -312,7 +316,7 @@ objects:
       name: ${NAME}-${ZONE}-work-flow-state-change-batch
     spec:
       concurrencyPolicy: Replace
-      schedule: "${CRON_MINUTES} 9 * * * " # Run daily at 9:xx AM UTC
+      schedule: "${CRON_MINUTES} 8 * * * " # Run daily at 8:xx AM UTC
       jobTemplate:
         spec:
           template:


### PR DESCRIPTION
After investigation for BCGW production issue, we will do temporary fix for:
- Update our cron job for `workflow state code update' to 1 hour earlier (1am PST, use 8am UTC), so it won't run at the same time as the BCWG extract
- Increate the API requested/limit memory for production: 2Gi for limit, 650Mi for request.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-25.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-25.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-25.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)