### PR TITLE
Remove Certbot from TEST Deployment.

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -38,7 +38,6 @@ jobs:
               -p DB_TESTDATA=true
               -p AWS_USER_POOLS_WEB_CLIENT_ID="k3b9ip1vf85o4tkqvu5g4adgj"
               -p LOGOUT_CHAIN_URL="https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
-            post_rollout: oc create job "certbot-manual-$(date +%s)" --from=cronjob/certbot
           - name: admin
             file: admin/openshift.deploy.yml
             overwrite: true


### PR DESCRIPTION
Current TEST deployment fail because we don't have certbot anymore on TEST.
Remove the line n`post_rollout: oc create job "certbot-manual-$(date +%s)" --from=cronjob/certbot`.
Still keep the PROD one.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-43.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-43.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-43.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-43.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-43.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-43.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)