### PR TITLE
Fix database service name for backup container.

### DIFF
--- a/db/openshift.deploy.yml
+++ b/db/openshift.deploy.yml
@@ -298,7 +298,7 @@ objects:
                       value: "${MONTHLY_BACKUPS}"
                       optional: true
                     - name: DATABASE_SERVICE_NAME
-                      value: "${NAME}-${ZONE}-database"
+                      value: "${NAME}-${ZONE}-${COMPONENT}"
                     - name: DEFAULT_PORT
                       value: ${DATABASE_DEFAULT_PORT}
                     - name: POSTGRESQL_DATABASE


### PR DESCRIPTION
After fixing backup deployment on secrets and storage volume, the container still failed.
The template for database service name is also wrong, and the job has trouble connecting to the db.
- Fix DATABASE_SERVICE_NAME value.

Now dev is working:
![image](https://github.com/bcgov/nr-fom/assets/81595625/a03c9e0c-b2b0-47df-bfbb-2114da30b720)
![image](https://github.com/bcgov/nr-fom/assets/81595625/d3c81c3a-b9e1-4c05-aed2-4ff4f564878e)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-45.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-45.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-45.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-45.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-45.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-45.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)