### PR TITLE
fix: #692 Admin FOM should not be editable when commenting open.

### DIFF
--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.html
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.html
@@ -37,7 +37,7 @@
       </div>
 
       <div class="row" >
-          <div class="form-group col-md-2" *ngIf="!this.isCreate">
+          <div class="form-group col-md-2" *ngIf="!isCreate">
             <label>ID</label>
             <input
               type="text"
@@ -48,60 +48,87 @@
               [value]="originalProjectResponse.id"
             />
           </div>
+
           <div class="form-group col-md">
             <label>Commenting Open Date</label>
-            <div class="input-group">
+            <div>
+              <div class="input-group" *ngIf="isInitialState">
+                <input
+                  readonly
+                  type="text"
+                  class="form-control readonly-normal"
+                  placeholder="YYYY-MM-DD"
+                  bsDatepicker
+                  [minDate]="minOpeningDate"
+                  (keydown)="$event.preventDefault()"
+                  #openDate="bsDatepicker"
+                  id="commentingOpenDate"
+                  name="commentingOpenDate"
+                  formControlName="commentingOpenDate"
+                  [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD', adaptivePosition: true,
+                                containerClass: 'theme-dark-blue', showWeekNumbers: false }"
+                  (bsValueChange)="toggleClosedDate($event)"
+                  [appFormControl]="fg.get('commentingOpenDate')"
+                />
+                <div class="input-group-append">
+                  <button
+                    class="btn btn-icon" type="button" tabindex="-1" (click)="openDate.show()"
+                    [attr.aria-expanded]="openDate.isOpen">
+                    <em class="material-icons">date_range</em>
+                  </button>
+                </div>
+              </div>
               <input
-                readonly
-                type="text"
-                class="form-control readonly-normal"
-                placeholder="YYYY-MM-DD"
-                bsDatepicker
-                [minDate]="minOpeningDate"
-                (keydown)="$event.preventDefault()"
-                #openDate="bsDatepicker"
+                *ngIf="!isInitialState"
+                disabled
                 id="commentingOpenDate"
                 name="commentingOpenDate"
-                formControlName="commentingOpenDate"
-                [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD', adaptivePosition: true,
-                              containerClass: 'theme-dark-blue', showWeekNumbers: false }"
-                (bsValueChange)="toggleClosedDate($event)"
-                [appFormControl]="fg.get('commentingOpenDate')"
+                class="form-control"
+                type="text"
+                placeholder="YYYY"
+                [value]="getformatedDate('commentingOpenDate', 'YYYY-MM-DD')"
               />
-              <div class="input-group-append">
-                <button class="btn btn-icon"  type="button" tabindex="-1" (click)="openDate.show()"
-                        [attr.aria-expanded]="openDate.isOpen">
-                  <em class="material-icons">date_range</em>
-                </button>
-              </div>
             </div>
           </div>
+
           <div class="form-group col-md">
             <label>Commenting Closed Date</label>
-            <div class="input-group">
+            <div>
+              <div class="input-group" *ngIf="isInitialState">
+                <input
+                  readonly
+                  type="text"
+                  class="form-control readonly-normal"
+                  placeholder="YYYY-MM-DD"
+                  bsDatepicker
+                  [minDate]="minClosedDate"
+                  (keydown)="$event.preventDefault()"
+                  #closedDate="bsDatepicker"
+                  id="commentingClosedDate"
+                  name="commentingClosedDate"
+                  formControlName="commentingClosedDate"
+                  (bsValueChange)="validateClosedDate($event)"
+                  [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD', adaptivePosition: true,
+                  containerClass: 'theme-dark-blue', showWeekNumbers: false  }"
+                  [appFormControl]="fg.get('commentingClosedDate')"
+                />
+                <div class="input-group-append">
+                  <button class="btn btn-icon"  type="button" tabindex="-1" (click)="closedDate.show()"
+                      [attr.aria-expanded]="closedDate.isOpen">
+                    <em class="material-icons">date_range</em>
+                  </button>
+                </div>
+              </div>
               <input
-                readonly
-                type="text"
-                class="form-control readonly-normal"
-                placeholder="YYYY-MM-DD"
-                bsDatepicker
-                [minDate]="minClosedDate"
-                (keydown)="$event.preventDefault()"
-                #closedDate="bsDatepicker"
+                *ngIf="!isInitialState"
+                disabled
                 id="commentingClosedDate"
                 name="commentingClosedDate"
-                formControlName="commentingClosedDate"
-                (bsValueChange)="validateClosedDate($event)"
-                [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD', adaptivePosition: true,
-                containerClass: 'theme-dark-blue', showWeekNumbers: false  }"
-                [appFormControl]="fg.get('commentingClosedDate')"
+                class="form-control"
+                type="text"
+                placeholder="YYYY"
+                [value]="getformatedDate('commentingClosedDate', 'YYYY-MM-DD')"
               />
-              <div class="input-group-append">
-                <button class="btn btn-icon"  type="button" tabindex="-1" (click)="closedDate.show()"
-                        [attr.aria-expanded]="closedDate.isOpen">
-                  <em class="material-icons">date_range</em>
-                </button>
-              </div>
             </div>
           </div>
         </div>
@@ -109,8 +136,9 @@
         <div class="row">
 
           <div class="form-group col">
-            <label for="op-start-year" [ngClass]="{'required': true}">Start of Operations</label>
+            <label for="op-start-year" [ngClass]="{'required': isInitialState}">Start of Operations</label>
             <input
+              *ngIf="isInitialState"
               readonly
               id="op-start-year"
               name="op-start-year"
@@ -123,6 +151,16 @@
               [bsConfig]="bsConfig"
               [appFormControl]="fg.get('opStartDate')"
             />
+            <input
+              *ngIf="!isInitialState"
+              disabled
+              id="op-start-year"
+              name="op-start-year"
+              class="form-control"
+              type="text"
+              placeholder="YYYY"
+              [value]="getformatedDate('opStartDate')"
+            />
             <div class="invalid-feedback" 
               *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('opStartDate')) 
                 && getErrorMessage('opStartDate', 'required')">
@@ -130,8 +168,9 @@
             </div>
           </div>
           <div class="form-group col">
-            <label for="op-end-year" [ngClass]="{'required': true}">End of Operations</label>
+            <label for="op-end-year" [ngClass]="{'required': isInitialState}">End of Operations</label>
             <input
+              *ngIf="isInitialState"
               readonly
               id="op-end-year"
               name="op-end-year"
@@ -143,6 +182,16 @@
               (keydown)="$event.preventDefault()"
               [bsConfig]="bsConfig"
               [appFormControl]="fg.get('opEndDate')"
+            />
+            <input
+              *ngIf="!isInitialState"
+              disabled
+              id="op-end-year"
+              name="op-end-year"
+              class="form-control"
+              type="text"
+              placeholder="YYYY"
+              [value]="getformatedDate('opEndDate')"
             />
             <div class="invalid-feedback" 
               *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('opEndDate')) 
@@ -159,8 +208,8 @@
 
         <div class="row">
           <div class="form-group col">
-            <label [ngClass]="{'required': this.isCreate}">Type of Plan Holder</label>
-            <select *ngIf="this.isCreate"
+            <label [ngClass]="{'required': isCreate}">Type of Plan Holder</label>
+            <select *ngIf="isCreate"
                 class="form-control"
                 formControlName="projectPlanCode"
                 (change)="onProjectPlanChange($event)"
@@ -171,7 +220,7 @@
                 [selected]="option.code === fg.get('projectPlanCode').value" 
                 [innerHTML]="option.description"> </option>
             </select>
-            <input *ngIf="!this.isCreate" type="text"
+            <input *ngIf="!isCreate" type="text"
               class="form-control"
               id="projectPlanDescId"
               name="projectPlanDescription"
@@ -187,15 +236,23 @@
           <!-- FSP ID Input -->
           <div class="form-group col"
             *ngIf="fg.get('projectPlanCode').value == projectPlanCodeEnum.Fsp">
-            <label for="fsp-id" [ngClass]="{'required': true}" style="white-space: nowrap;"
+            <label for="fsp-id" [ngClass]="{'required': isInitialState}" style="white-space: nowrap;"
             >FSP ID</label>
             <input
+              *ngIf="isInitialState"
               type="number"
               class="form-control"
               id="fsp-id"
               name="fsp-id"
               formControlName="fspId"
               [appFormControl]="fg.get('fspId')"
+            />
+            <input *ngIf="!isInitialState" type="text"
+                class="form-control"
+                id="fsp-id"
+                name="fsp-id"
+                disabled
+                [value]="fg.get('fspId').value"
             />
             <div class="invalid-feedback" 
               *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('fspId'))">
@@ -207,15 +264,24 @@
           <!-- Woodlot Licence Number Input -->
           <div class="form-group col"
             *ngIf="fg.get('projectPlanCode').value == projectPlanCodeEnum.Woodlot">
-            <label for="woodlot-id" [ngClass]="{'required': true}" style="white-space: nowrap;"
+            <label for="woodlot-id" [ngClass]="{'required': isInitialState}" style="white-space: nowrap;"
             >Woodlot Licence Number</label>
             <input
+            *ngIf="isInitialState"
               type="text"
               class="form-control"
               id="woodlot-id"
               name="woodlot-id"
               formControlName="woodlotLicenseNumber"
               [appFormControl]="fg.get('woodlotLicenseNumber')"
+            />
+
+            <input *ngIf="!isInitialState" type="text"
+                class="form-control"
+                id="woodlot-id"
+                name="woodlot-id"
+                disabled
+                [value]="fg.get('woodlotLicenseNumber').value"
             />
             <div class="invalid-feedback" 
               *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('woodlotLicenseNumber'))">
@@ -232,10 +298,18 @@
         <div class="row">
           <div class="form-group col">
             <label for="district-list" style="white-space: nowrap;">District</label>
-            <select class="sort-comments form-control" [ngClass]="{'is-invalid': !districtIdSelect && isSubmitSaveClicked}" (change)="changeDistrictId($event)" id="district-list">
-              <option *ngIf="this.isCreate || !districtIdSelect">  </option>
+            <select *ngIf="isInitialState"
+              class="sort-comments form-control" [ngClass]="{'is-invalid': !districtIdSelect && isSubmitSaveClicked}" (change)="changeDistrictId($event)" id="district-list">
+              <option *ngIf="isCreate || !districtIdSelect">  </option>
               <option  [value]="district.id" *ngFor="let district of districts" [selected]="district.id === districtIdSelect" [innerHTML]=" district.name "> </option>
             </select>
+            <input *ngIf="!isInitialState" type="text"
+              class="form-control"
+              id="district"
+              name="district"
+              disabled
+              [value]="getDistrictDesc(fg.get('district').value)"
+            />
             <div class="invalid-feedback" 
               *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('district')) 
               && getErrorMessage('district', 'required')">
@@ -247,12 +321,22 @@
           <div class="form-group col">
             <label>FOM Name</label>
             <input
+              *ngIf="isInitialState"
               type="text"
               class="form-control"
               id="name"
               name="name"
               formControlName="name"
               [appFormControl]="fg.get('name')"
+            />
+            <input
+              *ngIf="!isInitialState"
+              type="text"
+              class="form-control"
+              id="name"
+              name="name"
+              disabled
+              [value]="fg.get('name').value"
             />
             <div class="invalid-feedback" 
               *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('name')) 
@@ -265,21 +349,22 @@
                 {{getErrorMessage('name', 'minLength')}}
             </div>
           </div>
+
           <div class="form-group col">
             <label>FOM Holder</label>
-            <select *ngIf="this.isCreate" 
+            <select *ngIf="isCreate" 
                 class="sort-comments form-control"
                 formControlName="forestClient"
                 [ngClass]="{'is-invalid': !forestClientSelect && isSubmitSaveClicked}" 
                 (change)="onForestClientChange($event)" 
                 id="forestClient-list">
-              <option *ngIf="this.isCreate">  </option>
+              <option *ngIf="isCreate">  </option>
               <option *ngFor="let client of forestClients" 
                 [ngValue]="client"  
                 [selected]="client.id === forestClientSelect" 
                 [innerHTML]=" client.name"> </option>
             </select>
-            <input *ngIf="!this.isCreate"
+            <input *ngIf="!isCreate"
                    type="text"
               class="form-control"
               id="forestId"
@@ -294,12 +379,14 @@
             </div>
           </div>
         </div>
+
         <div class="row" *ngIf="isHolderBctsManger()">
           <div class="form-group col">
-            <label [ngClass]="{'required': isHolderBctsManger()}">
+            <label [ngClass]="{'required': isInitialState}">
                 Timber Sales Manager Name
             </label>
             <input
+              *ngIf="isInitialState"
               type="text"
               class="form-control"
               id="mgr-name-id"
@@ -307,6 +394,15 @@
               maxlength="50"
               formControlName="bctsMgrName"
               [appFormControl]="fg.get('bctsMgrName')"
+            />
+            <input
+              *ngIf="!isInitialState"
+              type="text"
+              disabled
+              class="form-control"
+              id="mgr-name-id"
+              name="bctsMgrName"
+              [value]="fg.get('bctsMgrName').value"
             />
             <div class="invalid-feedback" 
               *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('bctsMgrName')) 
@@ -325,10 +421,13 @@
             </div>
           </div>
         </div>
+
         <div class="row">
           <div class="form-group col-md">
             <label>Description</label>
-            <textarea (keyup)="changeDescription($event)"
+            <textarea 
+              *ngIf="isInitialState"
+              (keyup)="changeDescription($event)"
               class="form-control" [ngClass]="{'is-invalid': !descriptionValue && isSubmitSaveClicked && !isCreate}"
               rows="3"
               id="description"
@@ -338,6 +437,14 @@
               maxlength="{{descriptionLimit}}"
             >
             </textarea>
+            <textarea
+              *ngIf="!isInitialState"
+              class="form-control"
+              id="description"
+              name="description"
+              disabled
+              [value]="fg.get('description').value"
+            ></textarea>
             <small>{{descriptionLimit-fg.get('description').value?.length}} characters remaining.</small>
             <div class="invalid-feedback" 
               *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('description')) 
@@ -346,7 +453,8 @@
             </div>
           </div>
         </div>
-      <section *ngIf="!this.isCreate && isCreateAttachmentAllowed()">
+
+      <section *ngIf="!isCreate && isCreateAttachmentAllowed()">
         <div class="row">
           <div class="form-group col-md-6">
             <strong>Newspaper Public Notice</strong>

--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.html
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.html
@@ -38,6 +38,7 @@
 
       <div class="row" >
           <div class="form-group col-md-2" *ngIf="!isCreate">
+            <!-- FOM ID: disabled after fom is created -->
             <label>ID</label>
             <input
               type="text"
@@ -49,10 +50,10 @@
             />
           </div>
 
+          <!-- Commenting Open Date: disabled when COMMENT_CLOSED -->
           <div class="form-group col-md">
             <label>Commenting Open Date</label>
-            <div>
-              <div class="input-group" *ngIf="isInitialState">
+              <div class="input-group" *ngIf="!isCommentingClosedState">
                 <input
                   readonly
                   type="text"
@@ -79,7 +80,7 @@
                 </div>
               </div>
               <input
-                *ngIf="!isInitialState"
+                *ngIf="isCommentingClosedState"
                 disabled
                 id="commentingOpenDate"
                 name="commentingOpenDate"
@@ -88,71 +89,76 @@
                 placeholder="YYYY"
                 [value]="getformatedDate('commentingOpenDate', 'YYYY-MM-DD')"
               />
-            </div>
           </div>
 
+          <!-- Commenting Closed Date: disabled when COMMENT_CLOSED -->
           <div class="form-group col-md">
             <label>Commenting Closed Date</label>
-            <div>
-              <div class="input-group" *ngIf="isInitialState">
-                <input
-                  readonly
-                  type="text"
-                  class="form-control readonly-normal"
-                  placeholder="YYYY-MM-DD"
-                  bsDatepicker
-                  [minDate]="minClosedDate"
-                  (keydown)="$event.preventDefault()"
-                  #closedDate="bsDatepicker"
-                  id="commentingClosedDate"
-                  name="commentingClosedDate"
-                  formControlName="commentingClosedDate"
-                  (bsValueChange)="validateClosedDate($event)"
-                  [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD', adaptivePosition: true,
-                  containerClass: 'theme-dark-blue', showWeekNumbers: false  }"
-                  [appFormControl]="fg.get('commentingClosedDate')"
-                />
-                <div class="input-group-append">
-                  <button class="btn btn-icon"  type="button" tabindex="-1" (click)="closedDate.show()"
-                      [attr.aria-expanded]="closedDate.isOpen">
-                    <em class="material-icons">date_range</em>
-                  </button>
-                </div>
-              </div>
+            <div class="input-group" *ngIf="!isCommentingClosedState">
               <input
-                *ngIf="!isInitialState"
-                disabled
+                readonly
+                type="text"
+                class="form-control readonly-normal"
+                placeholder="YYYY-MM-DD"
+                bsDatepicker
+                [minDate]="minClosedDate"
+                (keydown)="$event.preventDefault()"
+                #closedDate="bsDatepicker"
                 id="commentingClosedDate"
                 name="commentingClosedDate"
-                class="form-control"
-                type="text"
-                placeholder="YYYY"
-                [value]="getformatedDate('commentingClosedDate', 'YYYY-MM-DD')"
+                formControlName="commentingClosedDate"
+                (bsValueChange)="validateClosedDate($event)"
+                [bsConfig]="{ dateInputFormat: 'YYYY-MM-DD', adaptivePosition: true,
+                containerClass: 'theme-dark-blue', showWeekNumbers: false  }"
+                [appFormControl]="fg.get('commentingClosedDate')"
               />
+              <div class="input-group-append">
+                <button class="btn btn-icon"  type="button" tabindex="-1" (click)="closedDate.show()"
+                    [attr.aria-expanded]="closedDate.isOpen">
+                  <em class="material-icons">date_range</em>
+                </button>
+              </div>
             </div>
+            <input
+              *ngIf="isCommentingClosedState"
+              disabled
+              id="commentingClosedDate"
+              name="commentingClosedDate"
+              class="form-control"
+              type="text"
+              placeholder="YYYY"
+              [value]="getformatedDate('commentingClosedDate', 'YYYY-MM-DD')"
+            />
           </div>
         </div>
 
         <div class="row">
-
+          <!-- Start of Operations: disabled when COMMENT_OPEN -->
           <div class="form-group col">
-            <label for="op-start-year" [ngClass]="{'required': isInitialState}">Start of Operations</label>
+            <label for="op-start-year" [ngClass]="{'required': !isCommentingOpenState}">Start of Operations</label>
+            <div *ngIf="!isCommentingOpenState">
+              <input
+                readonly
+                id="op-start-year"
+                name="op-start-year"
+                class="form-control readonly-normal"
+                type="text"
+                placeholder="YYYY"
+                formControlName="opStartDate"
+                bsDatepicker
+                (keydown)="$event.preventDefault()"
+                [bsConfig]="bsConfig"
+                [appFormControl]="fg.get('opStartDate')"
+              />
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('opStartDate')) 
+                  && getErrorMessage('opStartDate', 'required')">
+                  {{getErrorMessage('opStartDate', 'required')}}
+              </div>
+            </div>
+
             <input
-              *ngIf="isInitialState"
-              readonly
-              id="op-start-year"
-              name="op-start-year"
-              class="form-control readonly-normal"
-              type="text"
-              placeholder="YYYY"
-              formControlName="opStartDate"
-              bsDatepicker
-              (keydown)="$event.preventDefault()"
-              [bsConfig]="bsConfig"
-              [appFormControl]="fg.get('opStartDate')"
-            />
-            <input
-              *ngIf="!isInitialState"
+              *ngIf="isCommentingOpenState"
               disabled
               id="op-start-year"
               name="op-start-year"
@@ -161,30 +167,38 @@
               placeholder="YYYY"
               [value]="getformatedDate('opStartDate')"
             />
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('opStartDate')) 
-                && getErrorMessage('opStartDate', 'required')">
-                {{getErrorMessage('opStartDate', 'required')}}
-            </div>
           </div>
+
+          <!-- End of Operations: disabled when COMMENT_OPEN -->
           <div class="form-group col">
-            <label for="op-end-year" [ngClass]="{'required': isInitialState}">End of Operations</label>
+            <label for="op-end-year" [ngClass]="{'required': !isCommentingOpenState}">End of Operations</label>
+            <div *ngIf="!isCommentingOpenState">
+              <input
+                readonly
+                id="op-end-year"
+                name="op-end-year"
+                class="form-control readonly-normal"
+                type="text"
+                placeholder="YYYY"
+                formControlName="opEndDate"
+                bsDatepicker
+                (keydown)="$event.preventDefault()"
+                [bsConfig]="bsConfig"
+                [appFormControl]="fg.get('opEndDate')"
+              />
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('opEndDate')) 
+                  && getErrorMessage('opEndDate', 'required')">
+                  {{getErrorMessage('opEndDate', 'required')}}
+              </div>
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('opEndDate')) 
+                  && getErrorMessage('opEndDate', 'minDate')">
+                  {{getErrorMessage('opEndDate', 'minDate')}}
+              </div>
+            </div>
             <input
-              *ngIf="isInitialState"
-              readonly
-              id="op-end-year"
-              name="op-end-year"
-              class="form-control readonly-normal"
-              type="text"
-              placeholder="YYYY"
-              formControlName="opEndDate"
-              bsDatepicker
-              (keydown)="$event.preventDefault()"
-              [bsConfig]="bsConfig"
-              [appFormControl]="fg.get('opEndDate')"
-            />
-            <input
-              *ngIf="!isInitialState"
+              *ngIf="isCommentingOpenState"
               disabled
               id="op-end-year"
               name="op-end-year"
@@ -193,33 +207,31 @@
               placeholder="YYYY"
               [value]="getformatedDate('opEndDate')"
             />
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('opEndDate')) 
-                && getErrorMessage('opEndDate', 'required')">
-                {{getErrorMessage('opEndDate', 'required')}}
-            </div>
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('opEndDate')) 
-                && getErrorMessage('opEndDate', 'minDate')">
-                {{getErrorMessage('opEndDate', 'minDate')}}
-            </div>
           </div>
         </div>
 
         <div class="row">
           <div class="form-group col">
+            <!-- Type of Plan Holder: disabled after fom is created -->
             <label [ngClass]="{'required': isCreate}">Type of Plan Holder</label>
-            <select *ngIf="isCreate"
-                class="form-control"
-                formControlName="projectPlanCode"
-                (change)="onProjectPlanChange($event)"
-                [ngClass]="{'is-invalid': !fg.get('projectPlanCode').value && isSubmitSaveClicked}" 
-                id="projectPlanSelectId">
-              <option *ngFor="let option of projectPlanOptions" 
-                [value]="option.code"
-                [selected]="option.code === fg.get('projectPlanCode').value" 
-                [innerHTML]="option.description"> </option>
-            </select>
+            <div *ngIf="isCreate">
+              <select
+                  class="form-control"
+                  formControlName="projectPlanCode"
+                  (change)="onProjectPlanChange($event)"
+                  [ngClass]="{'is-invalid': !fg.get('projectPlanCode').value && isSubmitSaveClicked}" 
+                  id="projectPlanSelectId">
+                <option *ngFor="let option of projectPlanOptions" 
+                  [value]="option.code"
+                  [selected]="option.code === fg.get('projectPlanCode').value" 
+                  [innerHTML]="option.description"> </option>
+              </select>
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('projectPlanCode')) 
+                && getErrorMessage('projectPlanCode', 'required')">
+                {{getErrorMessage('projectPlanCode', 'required')}}
+              </div>
+            </div>
             <input *ngIf="!isCreate" type="text"
               class="form-control"
               id="projectPlanDescId"
@@ -227,82 +239,87 @@
               disabled
               [value]="getProjectPlanDesc()"
             />
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('projectPlanCode')) 
-              && getErrorMessage('projectPlanCode', 'required')">
-              {{getErrorMessage('projectPlanCode', 'required')}}
-            </div>
           </div>
-          <!-- FSP ID Input -->
+
+          <!-- FSP ID: disabled when COMMENT_OPEN -->
           <div class="form-group col"
             *ngIf="fg.get('projectPlanCode').value == projectPlanCodeEnum.Fsp">
-            <label for="fsp-id" [ngClass]="{'required': isInitialState}" style="white-space: nowrap;"
+            <label for="fsp-id" [ngClass]="{'required': !isCommentingOpenState}" style="white-space: nowrap;"
             >FSP ID</label>
-            <input
-              *ngIf="isInitialState"
-              type="number"
-              class="form-control"
-              id="fsp-id"
-              name="fsp-id"
-              formControlName="fspId"
-              [appFormControl]="fg.get('fspId')"
-            />
-            <input *ngIf="!isInitialState" type="text"
+            <div *ngIf="!isCommentingOpenState">
+              <input
+                type="number"
                 class="form-control"
                 id="fsp-id"
                 name="fsp-id"
-                disabled
-                [value]="fg.get('fspId').value"
-            />
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('fspId'))">
-              <div>{{getErrorMessage('fspId', 'required')}}</div>
-              <div>{{getErrorMessage('fspId', 'numeric')}}</div>
+                formControlName="fspId"
+                [appFormControl]="fg.get('fspId')"
+              />
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('fspId'))">
+                <div>{{getErrorMessage('fspId', 'required')}}</div>
+                <div>{{getErrorMessage('fspId', 'numeric')}}</div>
+              </div>
             </div>
+            <input *ngIf="isCommentingOpenState" type="text"
+              class="form-control"
+              id="fsp-id"
+              name="fsp-id"
+              disabled
+              [value]="fg.get('fspId').value"
+            />
           </div>
 
-          <!-- Woodlot Licence Number Input -->
+          <!-- Woodlot Licence Number: disabled when COMMENT_OPEN -->
           <div class="form-group col"
             *ngIf="fg.get('projectPlanCode').value == projectPlanCodeEnum.Woodlot">
-            <label for="woodlot-id" [ngClass]="{'required': isInitialState}" style="white-space: nowrap;"
+            <label for="woodlot-id" [ngClass]="{'required': !isCommentingOpenState}" style="white-space: nowrap;"
             >Woodlot Licence Number</label>
-            <input
-            *ngIf="isInitialState"
-              type="text"
-              class="form-control"
-              id="woodlot-id"
-              name="woodlot-id"
-              formControlName="woodlotLicenseNumber"
-              [appFormControl]="fg.get('woodlotLicenseNumber')"
-            />
-
-            <input *ngIf="!isInitialState" type="text"
+            <div *ngIf="!isCommentingOpenState">
+              <input
+                type="text"
                 class="form-control"
                 id="woodlot-id"
                 name="woodlot-id"
-                disabled
-                [value]="fg.get('woodlotLicenseNumber').value"
-            />
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('woodlotLicenseNumber'))">
-              <div>
-                {{getErrorMessage('woodlotLicenseNumber', 'required')}}
-              </div>
-              <div>
-                {{getErrorMessage('woodlotLicenseNumber', 'woodlotFormat')}}
+                formControlName="woodlotLicenseNumber"
+                [appFormControl]="fg.get('woodlotLicenseNumber')"
+              />
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('woodlotLicenseNumber'))">
+                <div>
+                  {{getErrorMessage('woodlotLicenseNumber', 'required')}}
+                </div>
+                <div>
+                  {{getErrorMessage('woodlotLicenseNumber', 'woodlotFormat')}}
+                </div>
               </div>
             </div>
+            <input *ngIf="isCommentingOpenState" type="text"
+              class="form-control"
+              id="woodlot-id"
+              name="woodlot-id"
+              disabled
+              [value]="fg.get('woodlotLicenseNumber').value"
+            />
           </div>
         </div>
 
+        <!-- District: disabled after INITIAL -->
         <div class="row">
           <div class="form-group col">
             <label for="district-list" style="white-space: nowrap;">District</label>
-            <select *ngIf="isInitialState"
-              class="sort-comments form-control" [ngClass]="{'is-invalid': !districtIdSelect && isSubmitSaveClicked}" (change)="changeDistrictId($event)" id="district-list">
-              <option *ngIf="isCreate || !districtIdSelect">  </option>
-              <option  [value]="district.id" *ngFor="let district of districts" [selected]="district.id === districtIdSelect" [innerHTML]=" district.name "> </option>
-            </select>
+            <div *ngIf="isInitialState">
+              <select
+                class="sort-comments form-control" [ngClass]="{'is-invalid': !districtIdSelect && isSubmitSaveClicked}" (change)="changeDistrictId($event)" id="district-list">
+                <option *ngIf="isCreate || !districtIdSelect">  </option>
+                <option  [value]="district.id" *ngFor="let district of districts" [selected]="district.id === districtIdSelect" [innerHTML]=" district.name "> </option>
+              </select>
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('district')) 
+                && getErrorMessage('district', 'required')">
+                {{getErrorMessage('district', 'required')}}
+              </div>
+            </div>
             <input *ngIf="!isInitialState" type="text"
               class="form-control"
               id="district"
@@ -310,27 +327,35 @@
               disabled
               [value]="getDistrictDesc(fg.get('district').value)"
             />
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('district')) 
-              && getErrorMessage('district', 'required')">
-              {{getErrorMessage('district', 'required')}}
-            </div>
           </div>
         </div>
+
+        <!-- FOM Name disabled when COMMENT_OPEN -->
         <div class="row">
           <div class="form-group col">
             <label>FOM Name</label>
+            <div *ngIf="!isCommentingOpenState">
+              <input
+                type="text"
+                class="form-control"
+                id="name"
+                name="name"
+                formControlName="name"
+                [appFormControl]="fg.get('name')"
+              />
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('name')) 
+                && getErrorMessage('name', 'required')">
+                {{getErrorMessage('name', 'required')}}
+              </div>
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('name')) 
+                  && getErrorMessage('name', 'minLength')">
+                  {{getErrorMessage('name', 'minLength')}}
+              </div>
+            </div>
             <input
-              *ngIf="isInitialState"
-              type="text"
-              class="form-control"
-              id="name"
-              name="name"
-              formControlName="name"
-              [appFormControl]="fg.get('name')"
-            />
-            <input
-              *ngIf="!isInitialState"
+              *ngIf="isCommentingOpenState"
               type="text"
               class="form-control"
               id="name"
@@ -338,18 +363,9 @@
               disabled
               [value]="fg.get('name').value"
             />
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('name')) 
-              && getErrorMessage('name', 'required')">
-              {{getErrorMessage('name', 'required')}}
-            </div>
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('name')) 
-                && getErrorMessage('name', 'minLength')">
-                {{getErrorMessage('name', 'minLength')}}
-            </div>
           </div>
 
+          <!-- FOM Holder: disabled after fom is created -->
           <div class="form-group col">
             <label>FOM Holder</label>
             <select *ngIf="isCreate" 
@@ -380,23 +396,40 @@
           </div>
         </div>
 
+        <!-- Timber Sales Manager Name: disabled when COMMENT_OPEN -->
         <div class="row" *ngIf="isHolderBctsManger()">
           <div class="form-group col">
-            <label [ngClass]="{'required': isInitialState}">
+            <label [ngClass]="{'required': !isCommentingOpenState}">
                 Timber Sales Manager Name
             </label>
+            <div *ngIf="!isCommentingOpenState">
+              <input
+                type="text"
+                class="form-control"
+                id="mgr-name-id"
+                name="bctsMgrName"
+                maxlength="50"
+                formControlName="bctsMgrName"
+                [appFormControl]="fg.get('bctsMgrName')"
+              />
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('bctsMgrName')) 
+                && getErrorMessage('bctsMgrName', 'required')">
+                {{getErrorMessage('bctsMgrName', 'required')}}
+              </div>
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('bctsMgrName')) 
+                  && getErrorMessage('bctsMgrName', 'minLength')">
+                  {{getErrorMessage('bctsMgrName', 'minLength')}}
+              </div>
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('bctsMgrName')) 
+                  && getErrorMessage('bctsMgrName', 'maxLength')">
+                  {{getErrorMessage('bctsMgrName', 'maxLength')}}
+              </div>
+            </div>
             <input
-              *ngIf="isInitialState"
-              type="text"
-              class="form-control"
-              id="mgr-name-id"
-              name="bctsMgrName"
-              maxlength="50"
-              formControlName="bctsMgrName"
-              [appFormControl]="fg.get('bctsMgrName')"
-            />
-            <input
-              *ngIf="!isInitialState"
+              *ngIf="isCommentingOpenState"
               type="text"
               disabled
               class="form-control"
@@ -404,53 +437,39 @@
               name="bctsMgrName"
               [value]="fg.get('bctsMgrName').value"
             />
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('bctsMgrName')) 
-              && getErrorMessage('bctsMgrName', 'required')">
-              {{getErrorMessage('bctsMgrName', 'required')}}
-            </div>
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('bctsMgrName')) 
-                && getErrorMessage('bctsMgrName', 'minLength')">
-                {{getErrorMessage('bctsMgrName', 'minLength')}}
-            </div>
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('bctsMgrName')) 
-                && getErrorMessage('bctsMgrName', 'maxLength')">
-                {{getErrorMessage('bctsMgrName', 'maxLength')}}
-            </div>
           </div>
         </div>
 
+        <!-- Description: disabled when COMMENT_OPEN -->
         <div class="row">
           <div class="form-group col-md">
             <label>Description</label>
-            <textarea 
-              *ngIf="isInitialState"
-              (keyup)="changeDescription($event)"
-              class="form-control" [ngClass]="{'is-invalid': !descriptionValue && isSubmitSaveClicked && !isCreate}"
-              rows="3"
-              id="description"
-              name="description"
-              formControlName="description"
-              [appFormControl]="fg.get('description')"
-              maxlength="{{descriptionLimit}}"
-            >
-            </textarea>
+            <div *ngIf="!isCommentingOpenState">
+              <textarea
+                (keyup)="changeDescription($event)"
+                class="form-control" [ngClass]="{'is-invalid': !descriptionValue && isSubmitSaveClicked && !isCreate}"
+                rows="3"
+                id="description"
+                name="description"
+                formControlName="description"
+                [appFormControl]="fg.get('description')"
+                maxlength="{{descriptionLimit}}"
+              ></textarea>
+              <small>{{descriptionLimit-fg.get('description').value?.length}} characters remaining.</small>
+              <div class="invalid-feedback" 
+                *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('description')) 
+                && getErrorMessage('description', 'required')">
+                {{getErrorMessage('description', 'required')}}
+              </div>
+            </div>
             <textarea
-              *ngIf="!isInitialState"
+              *ngIf="isCommentingOpenState"
               class="form-control"
               id="description"
               name="description"
               disabled
               [value]="fg.get('description').value"
             ></textarea>
-            <small>{{descriptionLimit-fg.get('description').value?.length}} characters remaining.</small>
-            <div class="invalid-feedback" 
-              *ngIf="(isSubmitSaveClicked || fieldTouchedOrDirty('description')) 
-              && getErrorMessage('description', 'required')">
-              {{getErrorMessage('description', 'required')}}
-            </div>
           </div>
         </div>
 

--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
@@ -445,8 +445,8 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
     return desc;
   }
 
-  getformatedDate(yearField, format = 'YYYY') {
-    return moment(this.fg.get(yearField).value).format(format);
+  getformatedDate(field, format = 'YYYY') {
+    return moment(this.fg.get(field).value).format(format);
   }
 
   /**

--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
@@ -69,6 +69,8 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
   public districtIdSelect: any = null;
   public forestClientSelect: any = null;
   public isInitialState: boolean = true;
+  public isCommentingOpenState: boolean = false;
+  public isCommentingClosedState: boolean = false;
   public isPublishState: boolean = false;
   files: any[] = [];
   maxFileSize: number = MAX_FILEUPLOAD_SIZE.DOCUMENT;
@@ -171,6 +173,8 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
 
         this.forestClientSelect = this.originalProjectResponse.forestClient.id;
         this.isInitialState = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.Initial;
+        this.isCommentingOpenState = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.CommentOpen;
+        this.isCommentingClosedState = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.CommentClosed;
         this.isPublishState = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.Published;
 
         this.attachmentResolverSvc.getAttachments(this.originalProjectResponse.id)

--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
@@ -38,11 +38,11 @@ type ApplicationPageType = 'create' | 'edit';
 @Component({
     standalone: true,
     imports: [
-        NgIf, 
-        FormsModule, 
-        ReactiveFormsModule, 
-        BsDatepickerModule, 
-        NgClass, 
+        NgIf,
+        FormsModule,
+        ReactiveFormsModule,
+        BsDatepickerModule,
+        NgClass,
         NgFor,
         AppFormControlDirective,
         NewlinesPipe,
@@ -69,6 +69,7 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
   public districtIdSelect: any = null;
   public forestClientSelect: any = null;
   public isPublishState: boolean = false;
+  public isCommentingOpen: boolean = false;
   files: any[] = [];
   maxFileSize: number = MAX_FILEUPLOAD_SIZE.DOCUMENT;
   publicNoticeContent: any;
@@ -97,12 +98,12 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
   private scrollToFragment: string = null;
   private snackBarRef: MatSnackBarRef<SimpleSnackBar> = null;
   private ngUnsubscribe: Subject<void> = new Subject<void>();
-  
+
   // bsDatepicker config object
   readonly bsConfig = {
-    dateInputFormat: 'YYYY', 
-    minMode: 'year', 
-    minDate: moment().toDate(), 
+    dateInputFormat: 'YYYY',
+    minMode: 'year',
+    minDate: moment().toDate(),
     maxDate: moment().add(7, 'years').toDate(), // current + 7 years
     containerClass: 'theme-dark-blue'
   } as Partial<BsDatepickerConfig>
@@ -127,7 +128,7 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
   get isCreate() {
     return this.state === 'create';
   }
-  
+
   get isLoading() {
     return this.stateSvc.loading;
   }
@@ -171,6 +172,8 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
         this.forestClientSelect = this.originalProjectResponse.forestClient.id;
 
         this.isPublishState = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.Published;
+
+        this.isCommentingOpen = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.CommentOpen;
 
         this.attachmentResolverSvc.getAttachments(this.originalProjectResponse.id)
           .then( (result) => {
@@ -335,11 +338,11 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
     this.fg.get('forestClient').setValue(forestClientField.value);
     this.forestClientSelect = parseInt(forestClientField.value.id);
 
-    // 'TIMBER SALES MANAGER' name field is required (to be validated) based on forestClient name 
-    // conditionally. Due to it's validation is annotation-based in fom-add-edit.form.ts 
+    // 'TIMBER SALES MANAGER' name field is required (to be validated) based on forestClient name
+    // conditionally. Due to it's validation is annotation-based in fom-add-edit.form.ts
     // (using @rxweb/reactive-form-validators), when forestClient is changed, bctsMgrName does not get
     // rerenderred (no ngIf, ngFor etc on this field).
-    // Just trigger the dynamic form field (with enable()) is probably easier than using 'ChangeDetectorRef'. 
+    // Just trigger the dynamic form field (with enable()) is probably easier than using 'ChangeDetectorRef'.
     this.fg.get('bctsMgrName').enable();
   }
 
@@ -356,7 +359,7 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
  /*
-  * Closed Date cannot be before (30 days after Comment Opening Date) 
+  * Closed Date cannot be before (30 days after Comment Opening Date)
   * if FOM status is in 'Commenting Open".
   */
   validateClosedDate(closedDate: Date): void {
@@ -457,7 +460,7 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
     const commentingClosedDateField = fg.get('commentingClosedDate');
     const closeDatePipe = this.datePipe.transform(fg.value.commentingClosedDate,'yyyy-MM-dd');
     commentingClosedDateField.setValue(closeDatePipe);
-    if ((user.isMinistry && !user.isForestClient) || 
+    if ((user.isMinistry && !user.isForestClient) ||
         commentingOpenDateField.value == null) {
       commentingClosedDateField.disable();
     }

--- a/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
+++ b/admin/src/app/foms/fom-add-edit/fom-add-edit.component.ts
@@ -68,8 +68,8 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
   public initialPublicDocument: any[] = [];
   public districtIdSelect: any = null;
   public forestClientSelect: any = null;
+  public isInitialState: boolean = true;
   public isPublishState: boolean = false;
-  public isCommentingOpen: boolean = false;
   files: any[] = [];
   maxFileSize: number = MAX_FILEUPLOAD_SIZE.DOCUMENT;
   publicNoticeContent: any;
@@ -170,10 +170,8 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
         }
 
         this.forestClientSelect = this.originalProjectResponse.forestClient.id;
-
+        this.isInitialState = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.Initial;
         this.isPublishState = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.Published;
-
-        this.isCommentingOpen = this.originalProjectResponse.workflowState.code === WorkflowStateEnum.CommentOpen;
 
         this.attachmentResolverSvc.getAttachments(this.originalProjectResponse.id)
           .then( (result) => {
@@ -438,6 +436,17 @@ export class FomAddEditComponent implements OnInit, AfterViewInit, OnDestroy {
         return item.code == this.originalProjectResponse.projectPlanCode
     })[0]["description"];
     return item;
+  }
+
+  getDistrictDesc(districtId) {
+    const desc = this.districts.filter((item) => {
+        return item.id == districtId
+    })[0]["name"];
+    return desc;
+  }
+
+  getformatedDate(yearField, format = 'YYYY') {
+    return moment(this.fg.get(yearField).value).format(format);
   }
 
   /**

--- a/admin/src/core/services/mock-user.ts
+++ b/admin/src/core/services/mock-user.ts
@@ -53,5 +53,6 @@ export function getFakeAllAccessUser(): User {
   user.isForestClient = true;
   user.clientIds.push('00001011')
   user.clientIds.push('00001012');
+  user.clientIds.push('00132188');
   return user;
 }

--- a/api/src/app/modules/project/project.service.ts
+++ b/api/src/app/modules/project/project.service.ts
@@ -131,9 +131,29 @@ export class ProjectService extends DataService<Project, Repository<Project>, Pr
       }
     }
 
-    // Cannot change commenting closed date when state is COMMENT_CLOSED.
+    // When COMMENT_CLOSED, cannot change: "Start of Operation", "End of Operation", "FSP ID", "District",
+    // "FOM Name", "Timber Sales Manager Name", "Description"
+    if (WorkflowStateEnum.COMMENT_OPEN == entity.workflowStateCode) {
+        if (entity.operationStartYear !== dto.operationStartYear ||
+            entity.operationEndYear !== dto.operationEndYear ||
+            entity.fspId !== dto.fspId ||
+            entity.districtId !== dto.districtId ||
+            entity.name !== dto.name ||
+            entity.bctsMgrName !== dto.bctsMgrName ||
+            entity.description !== dto.description
+        ) {
+          this.logger.debug(`Cannot change "Start of Operation", "End of Operation", "FSP ID", "District",
+                            "FOM Name", "Timber Sales Manager Name", "Description" for state ${entity.workflowStateCode}.`);
+          return false;
+        }
+      }
+      
+    // When COMMENT_CLOSED, cannot change "commenting open date" "commenting closed date", "district".
     if (WorkflowStateEnum.COMMENT_CLOSED == entity.workflowStateCode) {
-      if (entity.commentingClosedDate !== dto.commentingClosedDate) {
+      if (entity.commentingOpenDate !== dto.commentingOpenDate ||
+          entity.commentingClosedDate !== dto.commentingClosedDate ||
+          entity.districtId !== dto.districtId
+      ) {
         this.logger.debug(`Cannot change commenting closed date for state ${entity.workflowStateCode}.`);
         return false;
       }

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -189,4 +189,4 @@ if (process.argv.length > 2 &&
   standaloneRunTestDataMigrations();
 } else {
   startApi();
-} 
+}


### PR DESCRIPTION
ref: #692 
Business requirement changes due to issue the licenses edit FOM during commenting open (description field) and it has legal consequence. New rule: All FOM fields should not be editable except attachments fields during commenting open. 

- Adjust fom-add-edit component so that fields are only new/editable during FOM initial state. On Commenting open and any other state they will be disabled. Some field are only editable during "create" (initial state).

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-43.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-43.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-43.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-43.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-43.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-43.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)