### PR TITLE
chore(ci): deploymentconfig deprecation

### DIFF
--- a/.github/workflows/merge-demo.yml
+++ b/.github/workflows/merge-demo.yml
@@ -55,7 +55,6 @@ jobs:
             file: api/openshift.deploy.yml
             overwrite: true
             parameters:
-              -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
               -p URL=fom-demo.apps.silver.devops.gov.bc.ca
               -p FOM_EMAIL_NOTIFY=FLNR.AdminServicesCariboo@gov.bc.ca
               -p DB_TESTDATA=true
@@ -69,7 +68,6 @@ jobs:
           - name: db
             file: db/openshift.deploy.yml
             overwrite: false
-            parameters: -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
           - name: init
             file: libs/openshift.init.yml
             overwrite: false

--- a/.github/workflows/merge-demo.yml
+++ b/.github/workflows/merge-demo.yml
@@ -87,5 +87,4 @@ jobs:
           overwrite: ${{ matrix.overwrite }}
           penetration_test: false
           parameters:
-            -p PROMOTE=ghcr.io/${{ github.repository }}/${{ matrix.name }}:${{ env.ZONE }}
             -p ZONE=${{ env.ZONE }} ${{ matrix.parameters }}

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -32,7 +32,6 @@ jobs:
             oc_version: "4.13"
             overwrite: true
             parameters:
-              -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
               -p URL=fom-test.nrs.gov.bc.ca
               -p FOM_EMAIL_NOTIFY=FLNR.AdminServicesCariboo@gov.bc.ca
               -p DB_TESTDATA=true
@@ -45,7 +44,6 @@ jobs:
           - name: db
             file: db/openshift.deploy.yml
             overwrite: false
-            parameters: -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
           - name: init
             file: libs/openshift.init.yml
             overwrite: false
@@ -84,7 +82,6 @@ jobs:
             oc_version: "4.13"
             overwrite: true
             parameters:
-              -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
               -p URL=fom.nrs.gov.bc.ca
               -p AWS_USER_POOLS_WEB_CLIENT_ID="4bu2n8at3m32a2fqnvd4t06la1"
               -p LOGOUT_CHAIN_URL="https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
@@ -97,7 +94,6 @@ jobs:
           - name: db
             file: db/openshift.deploy.yml
             overwrite: false
-            parameters: -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
           - name: init
             file: libs/openshift.init.yml
             overwrite: false

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -64,7 +64,6 @@ jobs:
           overwrite: ${{ matrix.overwrite }}
           penetration_test: false
           parameters:
-            -p PROMOTE=${{ github.repository }}/${{ matrix.name }}:${{ env.ZONE }}
             -p ZONE=${{ env.ZONE }} ${{ matrix.parameters }}
           post_rollout: ${{ matrix.post_rollout }}
 
@@ -117,7 +116,6 @@ jobs:
           overwrite: ${{ matrix.overwrite }}
           penetration_test: false
           parameters:
-            -p PROMOTE=${{ github.repository }}/${{ matrix.name }}:test
             -p ZONE=${{ env.ZONE }} ${{ matrix.parameters }}
           post_rollout: ${{ matrix.post_rollout }}
 

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -65,9 +65,24 @@ jobs:
             -p ZONE=${{ env.ZONE }} ${{ matrix.parameters }}
           post_rollout: ${{ matrix.post_rollout }}
 
+  prod-promotions:
+    name: Promote images to PROD
+    needs: [deploy-test]
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        component: [api, admin, db, public]
+    steps:
+      - uses: shrink/actions-docker-registry-tag@v4
+        with:
+          registry: ghcr.io
+          repository: ${{ github.repository }}/${{ matrix.component }}
+          target: test
+          tags: prod
+
   deploy-prod:
     name: PROD Deploys
-    needs: [deploy-test]
+    needs: [prod-promotions]
     environment: prod
     env:
       ZONE: prod
@@ -114,18 +129,3 @@ jobs:
           parameters:
             -p ZONE=${{ env.ZONE }} ${{ matrix.parameters }}
           post_rollout: ${{ matrix.post_rollout }}
-
-  image-promotions:
-    name: Promote images to PROD
-    needs: [deploy-prod]
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        component: [api, admin, db, public]
-    steps:
-      - uses: shrink/actions-docker-registry-tag@v4
-        with:
-          registry: ghcr.io
-          repository: ${{ github.repository }}/${{ matrix.component }}
-          target: test
-          tags: prod

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -33,45 +33,45 @@ jobs:
           parameters: -p ZONE=${{ github.event.number }}
           triggers: ('db/' 'libs/' 'api/' 'admin/' 'public/')  
 
-  # builds:
-  #   name: Builds
-  #   runs-on: ubuntu-22.04
-  #   permissions:
-  #     packages: write
-  #   strategy:
-  #     matrix:
-  #       package: [admin, api, db, public]
-  #       include:
-  #         - package: admin
-  #           build_context: ./
-  #           build_file: admin/Dockerfile
-  #           triggers: ('admin/' 'libs/')
-  #         - package: api
-  #           build_context: ./
-  #           build_file: api/Dockerfile
-  #           triggers: ('api/' 'libs/')
-  #         - package: db
-  #           triggers: ('db')
-  #         - package: public
-  #           build_context: ./
-  #           build_file: public/Dockerfile
-  #           triggers: ('public/' 'libs/')
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: bcgov-nr/action-builder-ghcr@v2.2.0
-  #       with:
-  #         package: ${{ matrix.package }}
-  #         build_context: ${{ matrix.build_context }}
-  #         build_file: ${{ matrix.build_file }}
-  #         keep_versions: 100
-  #         tag: ${{ github.event.number }}
-  #         tag_fallback: test
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         triggers: ${{ matrix.triggers }}
+  builds:
+    name: Builds
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [admin, api, db, public]
+        include:
+          - package: admin
+            build_context: ./
+            build_file: admin/Dockerfile
+            triggers: ('admin/' 'libs/')
+          - package: api
+            build_context: ./
+            build_file: api/Dockerfile
+            triggers: ('api/' 'libs/')
+          - package: db
+            triggers: ('db')
+          - package: public
+            build_context: ./
+            build_file: public/Dockerfile
+            triggers: ('public/' 'libs/')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bcgov-nr/action-builder-ghcr@v2.2.0
+        with:
+          package: ${{ matrix.package }}
+          build_context: ${{ matrix.build_context }}
+          build_file: ${{ matrix.build_file }}
+          keep_versions: 100
+          tag: ${{ github.event.number }}
+          tag_fallback: test
+          token: ${{ secrets.GITHUB_TOKEN }}
+          triggers: ${{ matrix.triggers }}
 
   deploys:
     name: Deploys
-    # needs: [builds, init]
+    needs: [builds, init]
     needs: [init]
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -9,8 +9,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    name: Reset the deployment number
+  init:
+    name: Init
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-22.04
     outputs:
       route_number: ${{ steps.calculate.outputs.route_number }}
@@ -20,12 +22,6 @@ jobs:
         run: |
           echo "route_number=$((${{ github.event.number }} % 50))" >> $GITHUB_OUTPUT
 
-  prep:
-    name: Prep
-    permissions:
-      pull-requests: write
-    runs-on: ubuntu-22.04
-    steps:
       - name: OpenShift Init
         uses: bcgov-nr/action-deployer-openshift@v2.3.0
         with:
@@ -42,7 +38,6 @@ jobs:
   #   runs-on: ubuntu-22.04
   #   permissions:
   #     packages: write
-  #   needs: setup
   #   strategy:
   #     matrix:
   #       package: [admin, api, db, public]
@@ -76,8 +71,8 @@ jobs:
 
   deploys:
     name: Deploys
-    # needs: [prep, builds, setup]
-    needs: [prep, setup]
+    # needs: [builds, init]
+    needs: [init]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
@@ -118,6 +113,6 @@ jobs:
           overwrite: ${{ matrix.overwrite }}
           penetration_test: false
           parameters:
-            -p URL=fom-${{ needs.setup.outputs.route_number }}.apps.silver.devops.gov.bc.ca
+            -p URL=fom-${{ needs.init.outputs.route_number }}.apps.silver.devops.gov.bc.ca
             -p ZONE=${{ github.event.number }} ${{ matrix.parameters }}
           triggers: ${{ matrix.triggers }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -124,7 +124,6 @@ jobs:
           overwrite: ${{ matrix.overwrite }}
           penetration_test: false
           parameters:
-            -p PROMOTE=${{ github.repository }}/${{ matrix.name }}:${{ env.ZONE }}
             -p URL=fom-${{ env.ZONE }}.apps.silver.devops.gov.bc.ca
             -p ZONE=${{ env.ZONE }} ${{ matrix.parameters }}
           triggers: ${{ matrix.triggers }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -38,48 +38,49 @@ jobs:
           parameters: -p ZONE=${{ needs.setup.outputs.zone }}
           triggers: ('db/' 'libs/' 'api/' 'admin/' 'public/')  
 
-  builds:
-    name: Builds
-    runs-on: ubuntu-22.04
-    permissions:
-      packages: write
-    needs: setup
-    env:
-      ZONE: ${{ needs.setup.outputs.zone }}
-    strategy:
-      matrix:
-        package: [admin, api, db, public]
-        include:
-          - package: admin
-            build_context: ./
-            build_file: admin/Dockerfile
-            triggers: ('admin/' 'libs/')
-          - package: api
-            build_context: ./
-            build_file: api/Dockerfile
-            triggers: ('api/' 'libs/')
-          - package: db
-            triggers: ('db')
-          - package: public
-            build_context: ./
-            build_file: public/Dockerfile
-            triggers: ('public/' 'libs/')
-    steps:
-      - uses: actions/checkout@v4
-      - uses: bcgov-nr/action-builder-ghcr@v2.2.0
-        with:
-          package: ${{ matrix.package }}
-          build_context: ${{ matrix.build_context }}
-          build_file: ${{ matrix.build_file }}
-          keep_versions: 100
-          tag: ${{ env.ZONE }}
-          tag_fallback: test
-          token: ${{ secrets.GITHUB_TOKEN }}
-          triggers: ${{ matrix.triggers }}
+  # builds:
+  #   name: Builds
+  #   runs-on: ubuntu-22.04
+  #   permissions:
+  #     packages: write
+  #   needs: setup
+  #   env:
+  #     ZONE: ${{ needs.setup.outputs.zone }}
+  #   strategy:
+  #     matrix:
+  #       package: [admin, api, db, public]
+  #       include:
+  #         - package: admin
+  #           build_context: ./
+  #           build_file: admin/Dockerfile
+  #           triggers: ('admin/' 'libs/')
+  #         - package: api
+  #           build_context: ./
+  #           build_file: api/Dockerfile
+  #           triggers: ('api/' 'libs/')
+  #         - package: db
+  #           triggers: ('db')
+  #         - package: public
+  #           build_context: ./
+  #           build_file: public/Dockerfile
+  #           triggers: ('public/' 'libs/')
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: bcgov-nr/action-builder-ghcr@v2.2.0
+  #       with:
+  #         package: ${{ matrix.package }}
+  #         build_context: ${{ matrix.build_context }}
+  #         build_file: ${{ matrix.build_file }}
+  #         keep_versions: 100
+  #         tag: ${{ env.ZONE }}
+  #         tag_fallback: test
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         triggers: ${{ matrix.triggers }}
 
   deploys:
     name: Deploys
-    needs: [prep, builds, setup]
+    # needs: [prep, builds, setup]
+    needs: [prep, setup]
     runs-on: ubuntu-22.04
     env:
       ZONE: ${{ needs.setup.outputs.zone }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -13,19 +13,18 @@ jobs:
     name: Reset the deployment number
     runs-on: ubuntu-22.04
     outputs:
-      zone: ${{ steps.calculate.outputs.zone }}
+      route_number: ${{ steps.calculate.outputs.route_number }}
     steps:
       - name: Calculate the deployment number
         id: calculate
         run: |
-          echo "zone=$((${{ github.event.number }} % 50))" >> $GITHUB_OUTPUT
+          echo "route_number=$((${{ github.event.number }} % 50))" >> $GITHUB_OUTPUT
 
   prep:
     name: Prep
     permissions:
       pull-requests: write
     runs-on: ubuntu-22.04
-    needs: setup
     steps:
       - name: OpenShift Init
         uses: bcgov-nr/action-deployer-openshift@v2.3.0
@@ -35,7 +34,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           file: libs/openshift.init.yml
           overwrite: false
-          parameters: -p ZONE=${{ needs.setup.outputs.zone }}
+          parameters: -p ZONE=${{ github.event.number }}
           triggers: ('db/' 'libs/' 'api/' 'admin/' 'public/')  
 
   # builds:
@@ -44,8 +43,6 @@ jobs:
   #   permissions:
   #     packages: write
   #   needs: setup
-  #   env:
-  #     ZONE: ${{ needs.setup.outputs.zone }}
   #   strategy:
   #     matrix:
   #       package: [admin, api, db, public]
@@ -72,7 +69,7 @@ jobs:
   #         build_context: ${{ matrix.build_context }}
   #         build_file: ${{ matrix.build_file }}
   #         keep_versions: 100
-  #         tag: ${{ env.ZONE }}
+  #         tag: ${{ github.event.number }}
   #         tag_fallback: test
   #         token: ${{ secrets.GITHUB_TOKEN }}
   #         triggers: ${{ matrix.triggers }}
@@ -82,8 +79,6 @@ jobs:
     # needs: [prep, builds, setup]
     needs: [prep, setup]
     runs-on: ubuntu-22.04
-    env:
-      ZONE: ${{ needs.setup.outputs.zone }}
     timeout-minutes: 10
     strategy:
       matrix:
@@ -123,6 +118,6 @@ jobs:
           overwrite: ${{ matrix.overwrite }}
           penetration_test: false
           parameters:
-            -p URL=fom-${{ env.ZONE }}.apps.silver.devops.gov.bc.ca
-            -p ZONE=${{ env.ZONE }} ${{ matrix.parameters }}
+            -p URL=fom-${{ needs.setup.outputs.route_number }}.apps.silver.devops.gov.bc.ca
+            -p ZONE=${{ github.event.number }} ${{ matrix.parameters }}
           triggers: ${{ matrix.triggers }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -72,7 +72,6 @@ jobs:
   deploys:
     name: Deploys
     needs: [builds, init]
-    needs: [init]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -93,7 +93,6 @@ jobs:
             file: api/openshift.deploy.yml
             overwrite: true
             parameters:
-              -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
               -p REPLICA_COUNT=1
               -p FOM_EMAIL_NOTIFY=SIBIFSAF@victoria1.gov.bc.ca
               -p DB_TESTDATA=true
@@ -108,7 +107,6 @@ jobs:
           - name: db
             file: db/openshift.deploy.yml
             overwrite: false
-            parameters: -p OC_NAMESPACE=${{ vars.OC_NAMESPACE }}
             triggers: ('db/' 'libs/' 'api/' 'admin/' 'public/')
           - name: public
             file: public/openshift.deploy.yml

--- a/admin/openshift.deploy.yml
+++ b/admin/openshift.deploy.yml
@@ -67,8 +67,8 @@ objects:
         window.localStorage.setItem('fom_api_base_url', 'https://${URL}');
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: ${NAME}-${ZONE}
@@ -78,7 +78,7 @@ objects:
       revisionHistoryLimit: 10
       test: false
       strategy:
-        type: Rolling
+        type: RollingUpdate
         rollingParams:
           updatePeriodSeconds: 1
           intervalSeconds: 1
@@ -86,23 +86,14 @@ objects:
           maxUnavailable: 25%
           maxSurge: 25%
       activeDeadlineSeconds: 21600
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-${COMPONENT}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       template:
         metadata:
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-${COMPONENT}
@@ -170,7 +161,7 @@ objects:
           port: 80
           targetPort: 4200
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:

--- a/admin/openshift.deploy.yml
+++ b/admin/openshift.deploy.yml
@@ -87,7 +87,7 @@ objects:
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
-            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+            - image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
               securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]

--- a/admin/openshift.deploy.yml
+++ b/admin/openshift.deploy.yml
@@ -98,6 +98,8 @@ objects:
                   value: fom-${ZONE}-api
                 - name: fom_api_base_url
                   value: fom-${ZONE}-api
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 4200
                   protocol: TCP

--- a/admin/openshift.deploy.yml
+++ b/admin/openshift.deploy.yml
@@ -29,9 +29,12 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    required: true
+  - name: ORG
+    description: Organization name
+    value: bcgov
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - description: Number of replicas
     displayName: Replica Count
     name: REPLICA_COUNT
@@ -42,23 +45,11 @@ parameters:
     name: CADDY_DATA_PVC_SIZE
     required: true
     value: 22Mi
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${ZONE}-${COMPONENT}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
   - kind: ConfigMap
     apiVersion: v1
     data:
@@ -96,7 +87,7 @@ objects:
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-${COMPONENT}
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -44,9 +44,9 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    required: true
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: CRON_MINUTES
     description: Random number, 0-60, for scheduling cronjobs
     from: "[0-5]{1}[0-9]{1}"
@@ -81,23 +81,11 @@ parameters:
   - name: OC_NAMESPACE
     description: OpenShift namespace containing imported images
     required: true
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${ZONE}-api
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
   - apiVersion: v1
     kind: ConfigMap
     data:
@@ -149,7 +137,7 @@ objects:
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-api
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               imagePullPolicy: Always
               name: ${NAME}
               env:
@@ -316,7 +304,7 @@ objects:
               containers:
                 - name: ${NAME}-batch
                   # Full image name required due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2000216
-                  image: image-registry.apps.silver.devops.gov.bc.ca/${OC_NAMESPACE}/${NAME}-${ZONE}-${COMPONENT}:${ZONE}-api
+                  image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
                   imagePullPolicy: Always
                   args: ["-batchWorkflowStateChange"]
                   env:

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -120,8 +120,8 @@ objects:
         }
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: ${NAME}-${ZONE}
@@ -131,7 +131,7 @@ objects:
       revisionHistoryLimit: 10
       test: false
       strategy:
-        type: Rolling
+        type: RollingUpdate
         rollingParams:
           # Delay pod updates to account for time to run migrations
           updatePeriodSeconds: 30
@@ -139,23 +139,14 @@ objects:
           timeoutSeconds: 600
           maxUnavailable: 25%
           maxSurge: 25%
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-api
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       template:
         metadata:
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-api
@@ -283,7 +274,7 @@ objects:
           port: 80
           targetPort: ${{PORT}}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -204,6 +204,8 @@ objects:
                     secretKeyRef:
                       key: api_token
                       name: ${BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME}
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: ${{PORT}}
                   protocol: TCP

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -134,7 +134,7 @@ objects:
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
-            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+            - image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
               imagePullPolicy: Always
               name: ${NAME}
               env:
@@ -303,7 +303,7 @@ objects:
               containers:
                 - name: ${NAME}-batch
                   # Full image name required due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2000216
-                  image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
                   imagePullPolicy: Always
                   args: ["-batchWorkflowStateChange"]
                   env:
@@ -366,7 +366,7 @@ objects:
               containers:
                 - name: ${NAME}-batch
                   # Full image name required due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2000216
-                  image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
                   imagePullPolicy: Always
                   args: ["-batchForestClientDataRefresh"]
                   env:

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -78,9 +78,6 @@ parameters:
   - name: BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME
     description: OP secrete name for CLIENT API Token.
     value: "fom-client-app-api"
-  - name: OC_NAMESPACE
-    description: OpenShift namespace containing imported images
-    required: true
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"
@@ -369,7 +366,7 @@ objects:
               containers:
                 - name: ${NAME}-batch
                   # Full image name required due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2000216
-                  image: image-registry.apps.silver.devops.gov.bc.ca/${OC_NAMESPACE}/${NAME}-${ZONE}-${COMPONENT}:${ZONE}-api
+                  image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
                   imagePullPolicy: Always
                   args: ["-batchForestClientDataRefresh"]
                   env:

--- a/db/openshift.deploy.yml
+++ b/db/openshift.deploy.yml
@@ -95,9 +95,6 @@ parameters:
     description: Random number, 0-60, for scheduling cronjobs
     from: "[0-5]{1}[0-9]{1}"
     generate: expression
-  - name: OC_NAMESPACE
-    description: OpenShift namespace containing imported images
-    required: true
   - name: RANDOM_EXPRESSION
     description: Random expression to make sure deployments update
     from: "[a-zA-Z0-9]{32}"

--- a/db/openshift.deploy.yml
+++ b/db/openshift.deploy.yml
@@ -25,7 +25,11 @@ parameters:
     required: true
     value: 1Gi
   - name: REGISTRY
+    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: CPU_REQUEST
     value: 30m
   - name: MEMORY_REQUEST
@@ -34,9 +38,6 @@ parameters:
     value: 1000m
   - name: MEMORY_LIMIT
     value: 1Gi
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    required: true
   - name: URL
     description: Dummy parameter to make workflows easier
   ### Backup-Container starts here ###
@@ -111,22 +112,6 @@ objects:
         requests:
           storage: "${DB_PVC_SIZE}"
       storageClassName: netapp-file-standard
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${ZONE}-db
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
   - kind: Deployment
     apiVersion: apps/v1
     metadata:
@@ -156,7 +141,7 @@ objects:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}
           containers:
             - name: ${NAME}
-              image: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-db
+              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               ports:
                 - containerPort: 5432
                   protocol: TCP

--- a/db/openshift.deploy.yml
+++ b/db/openshift.deploy.yml
@@ -127,26 +127,17 @@ objects:
             name: ${REGISTRY}/${PROMOTE}
           referencePolicy:
             type: Local
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}
       labels:
         app: ${NAME}-${ZONE}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-db
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: Recreate
         recreateParams:
@@ -157,7 +148,7 @@ objects:
           name: ${NAME}-${ZONE}-${COMPONENT}
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           volumes:
             - name: ${NAME}-${ZONE}-${COMPONENT}
@@ -230,7 +221,7 @@ objects:
           protocol: TCP
           targetPort: 5432
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       sessionAffinity: None
       type: ClusterIP
   ### Backup-Container starts here ###

--- a/db/openshift.deploy.yml
+++ b/db/openshift.deploy.yml
@@ -98,6 +98,10 @@ parameters:
   - name: OC_NAMESPACE
     description: OpenShift namespace containing imported images
     required: true
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - kind: PersistentVolumeClaim
     apiVersion: v1
@@ -175,6 +179,8 @@ objects:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: database-user
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               resources:
                 requests:
                   cpu: ${CPU_REQUEST}
@@ -333,7 +339,7 @@ objects:
               containers:
                 - name: ${NAME}-${ZONE}-${COMPONENT}-restore
                   # use the same image as our database, so we can run the psql command
-                  image: image-registry.apps.silver.devops.gov.bc.ca/${OC_NAMESPACE}/${NAME}-${ZONE}-${COMPONENT}:${ZONE}-db
+                  image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
                   command: ["/bin/sh", "-c"]
                   args:
                   - |

--- a/db/openshift.deploy.yml
+++ b/db/openshift.deploy.yml
@@ -142,7 +142,7 @@ objects:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}
           containers:
             - name: ${NAME}
-              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+              image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
               ports:
                 - containerPort: 5432
                   protocol: TCP
@@ -336,7 +336,7 @@ objects:
               containers:
                 - name: ${NAME}-${ZONE}-${COMPONENT}-restore
                   # use the same image as our database, so we can run the psql command
-                  image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
                   command: ["/bin/sh", "-c"]
                   args:
                   - |

--- a/libs/openshift.init.yml
+++ b/libs/openshift.init.yml
@@ -36,8 +36,6 @@ parameters:
     description: Secret key for data encryption within database
     from: "[a-zA-Z0-9]{16}"
     generate: expression
-  - name: PROMOTE
-    description: Dummy parameter to make workflows easier
 objects:
   - apiVersion: v1
     kind: Secret

--- a/public/openshift.deploy.yml
+++ b/public/openshift.deploy.yml
@@ -67,8 +67,8 @@ objects:
         window.localStorage.setItem('fom_api_base_url', 'https://${URL}');
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: ${NAME}-${ZONE}
@@ -97,12 +97,12 @@ objects:
               kind: ImageStreamTag
               name: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-${COMPONENT}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       template:
         metadata:
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-${COMPONENT}
@@ -170,7 +170,7 @@ objects:
           port: 80
           targetPort: 4300
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:

--- a/public/openshift.deploy.yml
+++ b/public/openshift.deploy.yml
@@ -29,9 +29,9 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    required: true
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - description: Number of replicas
     displayName: Replica Count
     name: REPLICA_COUNT
@@ -43,22 +43,6 @@ parameters:
     required: true
     value: 22Mi
 objects:
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${ZONE}-${COMPONENT}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
   - kind: ConfigMap
     apiVersion: v1
     data:
@@ -86,18 +70,9 @@ objects:
           maxUnavailable: 25%
           maxSurge: 25%
       activeDeadlineSeconds: 21600
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-${COMPONENT}
       selector:
-        deployment: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       template:
         metadata:
           labels:
@@ -105,7 +80,7 @@ objects:
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${ZONE}-${COMPONENT}
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]

--- a/public/openshift.deploy.yml
+++ b/public/openshift.deploy.yml
@@ -66,7 +66,7 @@ objects:
       revisionHistoryLimit: 10
       test: false
       strategy:
-        type: Rolling
+        type: RollingUpdate
         rollingParams:
           updatePeriodSeconds: 1
           intervalSeconds: 1

--- a/public/openshift.deploy.yml
+++ b/public/openshift.deploy.yml
@@ -42,6 +42,10 @@ parameters:
     name: CADDY_DATA_PVC_SIZE
     required: true
     value: 22Mi
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - kind: ConfigMap
     apiVersion: v1
@@ -91,6 +95,8 @@ objects:
                   value: fom-${ZONE}-api
                 - name: fom_api_base_url
                   value: fom-${ZONE}-api
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 4300
                   protocol: TCP

--- a/public/openshift.deploy.yml
+++ b/public/openshift.deploy.yml
@@ -84,7 +84,7 @@ objects:
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
-            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+            - image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
               securityContext:
                 capabilities:
                   add: ["NET_BIND_SERVICE"]


### PR DESCRIPTION
Replaces deprecated Deployment Configs with Deployments. Also removes image streams and uses a randomly generated envar to ensure consistent rollouts.

Unfortunately there will be some downtime when this deploys.

Steps:
- Delete deployment configs and services for TEST database and backend
- Delete deployment configs and services for PROD database and backend
- Merge this PR
- Let deployments to TEST and PROD complete

Closes #687.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-1.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-1.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-1.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)