### PR TITLE
ci(fix): update tags for API cronjob

### DIFF
--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -306,7 +306,7 @@ objects:
               containers:
                 - name: ${NAME}-batch
                   # Full image name required due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2000216
-                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
+                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${TAG}
                   imagePullPolicy: Always
                   args: ["-batchWorkflowStateChange"]
                   env:
@@ -369,7 +369,7 @@ objects:
               containers:
                 - name: ${NAME}-batch
                   # Full image name required due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2000216
-                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
+                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${TAG}
                   imagePullPolicy: Always
                   args: ["-batchForestClientDataRefresh"]
                   env:


### PR DESCRIPTION
Update cronjobs to use the new tags.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-29.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-29.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-29.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)