### PR TITLE
chore(ci): cronjob image and simplify deploy trigger

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -87,12 +87,10 @@ jobs:
               -p DB_TESTDATA=true
               -p AWS_USER_POOLS_WEB_CLIENT_ID="7hpo4qa7j0hs0rkfl2pm0sto5k"
               -p LOGOUT_CHAIN_URL="https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
-            triggers: ('db/' 'libs/' 'api/')
           - name: admin
             file: admin/openshift.deploy.yml
             overwrite: true
             parameters: -p REPLICA_COUNT=1
-            triggers: ('db/' 'libs/' 'api/' 'admin/')
           - name: db
             file: db/openshift.deploy.yml
             overwrite: false
@@ -100,7 +98,6 @@ jobs:
             file: public/openshift.deploy.yml
             overwrite: true
             parameters: -p REPLICA_COUNT=1
-            triggers: ('db/' 'libs/' 'api/' 'public/')
     steps:
       - uses: bcgov-nr/action-deployer-openshift@v3.0.1
         with:
@@ -114,4 +111,4 @@ jobs:
             -p URL=fom-${{ needs.init.outputs.route_number }}.apps.silver.devops.gov.bc.ca
             -p ZONE=${{ github.event.number }} -p TAG=${{ github.event.number }}
             ${{ matrix.parameters }}
-          triggers: ${{ matrix.triggers }}
+          triggers: ('db/' 'libs/' 'api/' 'admin/' 'public/')

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -58,7 +58,7 @@ jobs:
             triggers: ('public/' 'libs/')
     steps:
       - uses: actions/checkout@v4
-      - uses: bcgov-nr/action-builder-ghcr@v2.2.0
+      - uses: bcgov-nr/action-builder-ghcr@v2.3.0
         with:
           package: ${{ matrix.package }}
           build_context: ${{ matrix.build_context }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -72,6 +72,9 @@ jobs:
   deploys:
     name: Deploys
     needs: [builds, init]
+    env:
+      LOGOUT_URL: https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi
+      LOGOUT_RETURN_URL: https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
@@ -86,7 +89,7 @@ jobs:
               -p FOM_EMAIL_NOTIFY=SIBIFSAF@victoria1.gov.bc.ca
               -p DB_TESTDATA=true
               -p AWS_USER_POOLS_WEB_CLIENT_ID="7hpo4qa7j0hs0rkfl2pm0sto5k"
-              -p LOGOUT_CHAIN_URL="https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
+              -p LOGOUT_CHAIN_URL="${{ env.LOGOUT_URL }}?retnow=1&returl=${{ env.LOGOUT_RETURN_URL }}"
             triggers: ('db/' 'libs/' 'api/')
           - name: admin
             file: admin/openshift.deploy.yml

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -58,7 +58,7 @@ jobs:
             triggers: ('public/' 'libs/')
     steps:
       - uses: actions/checkout@v4
-      - uses: bcgov-nr/action-builder-ghcr@v2.3.0
+      - uses: bcgov-nr/action-builder-ghcr@v2.2.0
         with:
           package: ${{ matrix.package }}
           build_context: ${{ matrix.build_context }}
@@ -72,9 +72,6 @@ jobs:
   deploys:
     name: Deploys
     needs: [builds, init]
-    env:
-      LOGOUT_URL: https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi
-      LOGOUT_RETURN_URL: https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
@@ -89,7 +86,7 @@ jobs:
               -p FOM_EMAIL_NOTIFY=SIBIFSAF@victoria1.gov.bc.ca
               -p DB_TESTDATA=true
               -p AWS_USER_POOLS_WEB_CLIENT_ID="7hpo4qa7j0hs0rkfl2pm0sto5k"
-              -p LOGOUT_CHAIN_URL="${{ env.LOGOUT_URL }}?retnow=1&returl=${{ env.LOGOUT_RETURN_URL }}"
+              -p LOGOUT_CHAIN_URL="https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri="
             triggers: ('db/' 'libs/' 'api/')
           - name: admin
             file: admin/openshift.deploy.yml
@@ -99,7 +96,6 @@ jobs:
           - name: db
             file: db/openshift.deploy.yml
             overwrite: false
-            triggers: ('db/' 'libs/' 'api/' 'admin/' 'public/')
           - name: public
             file: public/openshift.deploy.yml
             overwrite: true

--- a/db/openshift.deploy.yml
+++ b/db/openshift.deploy.yml
@@ -22,6 +22,9 @@ parameters:
   - name: TAG
     description: Image tag; e.g. PR number, latest or prod
     required: true
+  - name: CRONJOB_RESTORE_TAG
+    description: Image tag for database restore cronjob; e.g. PR number, latest or prod
+    value: prod
   - description: Volume space available for data, e.g. 512Mi, 2Gi.
     displayName: Database Volume Capacity
     name: DB_PVC_SIZE
@@ -339,7 +342,7 @@ objects:
               containers:
                 - name: ${NAME}-${ZONE}-${COMPONENT}-restore
                   # use the same image as our database, so we can run the psql command
-                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${ZONE}
+                  image: ${REGISTRY}/${ORG}/nr-fom/${COMPONENT}:${CRONJOB_RESTORE_TAG}
                   command: ["/bin/sh", "-c"]
                   args:
                   - |
@@ -384,7 +387,7 @@ objects:
                           echo "psql successfully reverted current failed db restore procedure. DB fom is back to original state. However, the restore procedure failed."
                           exit $db_restore_cmd_status
                         else
-                          echo "Error: psql failed to attmpt reverting failed db restore procedure. Please manually rename ${OLD_FOM_DATABASE_NAME} back to fom."
+                          echo "Error: psql failed to attempt reverting failed db restore procedure. Please manually rename ${OLD_FOM_DATABASE_NAME} back to fom."
                           exit $db_revert_restore_cmd_status
                         fi
                       else


### PR DESCRIPTION
Cleanup.  Verifies build triggers, simplifies deploy triggers and updates the image for a cronjob that's not currently in use.  Closes #723.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-35.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-35.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-35.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)