### PR TITLE
chore(ci): switch to gh default codeql

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,19 +33,6 @@ jobs:
             -Dsonar.projectKey=nr-fom
           sonar_token: ${{ secrets.SONAR_TOKEN }}
 
-  codeql:
-    name: CodeQL
-    if: ${{ ! github.event.pull_request.draft }}
-    needs: [tests]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-        with:
-          languages: javascript
-      - uses: github/codeql-action/analyze@v3
-
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:
     name: Trivy Security Scan


### PR DESCRIPTION
The switch to GitHub default CodeQL happened in the UI's settings.  This PR removes our manual code.

Resolves this alert too: https://github.com/bcgov/nr-fom/security/code-scanning/142


---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-37.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-37.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-37.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
 - [api](https://fom-37.apps.silver.devops.gov.bc.ca/api)
 - [admin](https://fom-37.apps.silver.devops.gov.bc.ca/admin)
 - [public](https://fom-37.apps.silver.devops.gov.bc.ca/public)

Once merged, code will be promoted and handed off to following workflow run.
 - [Main Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge-main.yml)