### PR TITLE
fix: #712 Fix LOGOUT_CHAIN_URL not available.

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -122,7 +122,7 @@ jobs:
               -p BATCH_CLIENT_RFSH_API_TKN_OP_SECRET_NAME="${{ inputs.batch_client_rfsh_api_tkn_op_secret_name }}"
               -p DB_TESTDATA=${{ inputs.db_testdata }}
               -p FOM_EMAIL_NOTIFY=${{ inputs.email_notify }}
-              -p LOGOUT_CHAIN_URL="{{ inputs.logout_chain_url }}"
+              -p LOGOUT_CHAIN_URL="${{ inputs.logout_chain_url }}"
           - name: admin
             overwrite: true
           - name: db

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: PROD (release)
 
 on:
   release:
-    types: published
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Ref: #712 
- Fix admin log out not working for missing LOGOUT_CHAIN_URL.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-4.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-4.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-4.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)