### PR TITLE
chore(ci): tag with release names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,4 +68,6 @@ jobs:
           registry: ghcr.io
           repository: ${{ github.repository }}/${{ matrix.component }}
           target: ${{ needs.deploy.outputs.tag }}
-          tags: prod
+          tags: |
+            prod
+            ${{ github.event.release.tag_name }}


### PR DESCRIPTION
If a release was used to deploy to prod, then tag those images with release numbers.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-6.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-6.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-6.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)