### PR TITLE
fix: #775 Openshift Deployment Memory Allocation and Desired Pods change.

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -137,8 +137,12 @@ jobs:
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
-          parameters:
-            -p ZONE=${{ inputs.target }} -p TAG=${{ needs.init.outputs.tag }}
-            -p URL=${{ needs.init.outputs.url }} -p REPLICA_COUNT=1
+
+          # Note: 'REPLICA_COUNT' setting not used for db and "1" for non-prod.
+          parameters: |
+            -p ZONE=${{ inputs.target }} 
+            -p TAG=${{ needs.init.outputs.tag }}
+            -p URL=${{ needs.init.outputs.url }}
+            ${{ inputs.environment != 'prod' && '-p REPLICA_COUNT=1' || '' }}
             ${{ matrix.parameters }}
           triggers: ${{ inputs.triggers }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -138,11 +138,9 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
 
-          # Note: 'REPLICA_COUNT' setting not used for db and "1" for non-prod.
           parameters: |
             -p ZONE=${{ inputs.target }} 
             -p TAG=${{ needs.init.outputs.tag }}
             -p URL=${{ needs.init.outputs.url }}
-            ${{ inputs.environment != 'prod' && '-p REPLICA_COUNT=1' || '' }}
             ${{ matrix.parameters }}
           triggers: ${{ inputs.triggers }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -138,7 +138,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
 
-          parameters: |
+          parameters:
             -p ZONE=${{ inputs.target }} 
             -p TAG=${{ needs.init.outputs.tag }}
             -p URL=${{ needs.init.outputs.url }}

--- a/api/openshift.deploy.yml
+++ b/api/openshift.deploy.yml
@@ -41,9 +41,9 @@ parameters:
   - name: CPU_REQUEST
     value: 30m
   - name: MEMORY_REQUEST
-    value: 150Mi
+    value: 200Mi
   - name: MEMORY_LIMIT
-    value: 1Gi
+    value: 2.2Gi
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io


### PR DESCRIPTION
ref: 775
Due to recent daily bcgw-extract failure, we will fix the following:
- Container memory limit increase, also increase request memory slightly.
- Fix bug for production pod running only in 1 pod.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-27.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-27.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-27.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)