### PR TITLE
fix: #787 District not receiving finalized email notification

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -21,7 +21,7 @@ on:
         type: boolean
       email_notify:
         description: Email address for notifications
-        default: SIBIFSAF@victoria1.gov.bc.ca
+        default: "" # prod notifications are sent to the district email address set in db.
         type: string
       environment:
         description: GitHub/OpenShift environment; usually PR number, test or prod

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,7 +24,7 @@ jobs:
       batch_client_rfsh_api_tkn_op_secret_name: fom-demo-client-app-api
       db_testdata: true
       environment: test
-      email_notify: FLNR.AdminServicesCariboo@gov.bc.ca
+      email_notify: nonexistent@gov.bc.ca  # lower environment fake email address to send
       logout_chain_url: https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=
       target: test
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,7 +24,7 @@ jobs:
       batch_client_rfsh_api_tkn_op_secret_name: fom-demo-client-app-api
       db_testdata: true
       environment: test
-      email_notify: nonexistent@gov.bc.ca  # lower environment fake email address to send
+      email_notify: Heartwood@gov.bc.ca  # TEST environment, set to team inbox.
       logout_chain_url: https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=
       target: test
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -53,6 +53,7 @@ jobs:
     uses: ./.github/workflows/.deploy.yml
     with:
       db_testdata: true
+      email_notify: nonexistent@gov.bc.ca  # lower environment fake email address to send
       triggers: ('db/' 'libs/' 'api/' 'admin/' 'public/')
 
   results:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -24,7 +24,6 @@ jobs:
       aws_user_pools_web_client_id: 4bu2n8at3m32a2fqnvd4t06la1
       batch_client_rfsh_api_tkn_op_secret_name: fom-client-app-api
       environment: prod
-      email_notify: FLNR.AdminServicesCariboo@gov.bc.ca
       logout_chain_url: https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=
       tag: ${{ inputs.tag }}
       target: prod


### PR DESCRIPTION
A district reported they did not receive several finalized FOM email.
The cause was PROD deployment for "**FOM_EMAIL_NOTIFY**" was set to some email address, it should be empty.
- Fix workflow and template for "**email_notify**" setting and default.
 

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-38.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-38.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-38.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)