### PR TITLE
chore(ci): drop vanity url from prod workflow

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -27,7 +27,6 @@ jobs:
       logout_chain_url: https://logon7.gov.bc.ca/clp-cgi/logoff.cgi?retnow=1&returl=https://loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/logout?redirect_uri=
       tag: ${{ inputs.tag }}
       target: prod
-      url: fom.nrs.gov.bc.ca
 
   images-backup:
     name: Backup images (PROD)


### PR DESCRIPTION
Remove PROD URL from workflows.  This is now happening independently.  The regular workflows will deploy non-vanity URLs, which can be ignored.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-38.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-38.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-38.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)