### PR TITLE
fix: #856 Interaction Attachment

### DIFF
--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.scss
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.scss
@@ -11,6 +11,9 @@ label {
 
 .interaction-detail-container {
   padding: 1.5rem 2rem;
+  .form-group {
+    margin-bottom: 1rem;
+  }
 }
 
 .title-container__title {

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
@@ -1,5 +1,5 @@
 import { MAX_FILEUPLOAD_SIZE } from '@admin-core/utils/constants';
-import { Component, Input } from '@angular/core';
+import { ChangeDetectorRef, Component, Input } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AttachmentResponse, AttachmentService, InteractionResponse } from '@api-client';
 import { IFormGroup, RxFormBuilder } from '@rxweb/reactive-form-validators';
@@ -58,6 +58,7 @@ export class InteractionDetailComponent {
     private configSvc: ConfigService,
     public attachmentSvc: AttachmentService,
     public attachmentResolverSvc: AttachmentResolverSvc,
+    private cdr: ChangeDetectorRef
   ) { }
 
   @Input() set selectedInteraction(interaction: InteractionResponse) {
@@ -67,9 +68,10 @@ export class InteractionDetailComponent {
     if (!this.editMode) {
       this.interactionFormGroup.disable();
     }
-    
     this.interaction.attachmentId? this.retrieveAttachment(this.interaction.attachmentId)
                                  : this.attachment = null;
+    // Force change detection to ensure child components render
+    this.cdr.detectChanges();
   }
   
   addNewFile(newFile: File) {

--- a/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
+++ b/admin/src/app/foms/interactions/interaction-detail/interaction-detail.component.ts
@@ -42,14 +42,14 @@ export class InteractionDetailComponent {
   file: File = null; // only 1 attachment for Interaction.
   maxFileSize: number = MAX_FILEUPLOAD_SIZE.DOCUMENT;
   fileContent: any;
-  /*
-  * Note: Stakeholder Engagement needs to allow 'application/vnd.ms-outlook' but the library 'ngx-dropzone' is having
-  * problem parsing it to the '(MIME) type'. It always returns '' empty string for type internally, resulting invalid type
-  * check with error message.
-  * To fix this, we allow all extension type at frontend as ['*'] for uploading, and let backend logic to validate the allowed 
-  * file type extension.
-  */
-  supportingFileTypes: string[] = ['*'];
+ 
+  supportingFileTypes: string[] = 
+  [ 'image/png', 'image/jpeg', 'image/jpg', 'application/pdf', 'image/tiff',
+    'application/pdf', 'text/plain', 'text/csv', 'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/rtf', 'application/vnd.ms-outlook'
+  ]
   attachment: AttachmentResponse;
   communicationDetailsLimit: number = 4000;
 

--- a/admin/src/core/components/file-upload-box/file-upload-box.component.ts
+++ b/admin/src/core/components/file-upload-box/file-upload-box.component.ts
@@ -62,8 +62,8 @@ export class UploadBoxComponent {
       return;
     }
     const file = files[0];
-    // Validate file type
-    if (!this.fileTypes.includes(file.type)) {
+
+    if (!this.isAcceptedFileType(file)) {
       this.invalidTypeText = 'The file type is not accepted';
       this.uploadedFile = null;
       this.fileUploaded.emit(null);
@@ -113,6 +113,25 @@ export class UploadBoxComponent {
     } else {
       this.outputFileContent.emit(null);
     }
+  }
+
+  /**
+   * Checks if the file type is accepted.
+   * For .msg (email) files, the file.type is often empty, so we also check the file extension.
+   */
+  private isAcceptedFileType(file: File): boolean {
+    const OUTLOOK_MIME = 'application/vnd.ms-outlook';
+    const MSG_EXTENSION = 'msg';
+    
+    const fileType = file.type || '';
+    const fileName = file.name || '';
+    const extension = fileName.split('.').pop()?.toLowerCase();
+    // Accept .msg files if parent accepts application/vnd.ms-outlook
+    if (fileType === OUTLOOK_MIME || extension === MSG_EXTENSION) {
+      return this.fileTypes.includes(OUTLOOK_MIME);
+    }
+    // Standard check
+    return this.fileTypes.includes(fileType);
   }
 
   remove() {


### PR DESCRIPTION
Previously the Stakeholder Engagement (Interaction) Detail component's upload always shows user "The file type is not accepted".
Other components upload function were fine.
This PR fixes the broken upload function:
- Supply allowed file types to the upload component.
- Adjust msg (email) type condition due to the file upload file does not have 'file.type' (for mime type), instead, check its extension.
- Add Angular 'ChangeDetectorRef' to force component rendering due to the third-party library component is not visible when the detail is initially loaded. 

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-7.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-7.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-7.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-7.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-7.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-7.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)