### PR TITLE
chore(ci): shai hulud 2 patch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,8 @@ services:
     entrypoint:
       - sh
       - -c
-      - cd libs && npm ci &&
-        cd ../api && npm i &&
+      - cd libs && npm ci --ignore-scripts &&
+        cd ../api && npm i --ignore-scripts &&
         npm run start:api
     environment:
       - DB_HOST=db
@@ -104,8 +104,8 @@ services:
     entrypoint:
       - sh
       - -c
-      - cd libs && npm ci &&
-        cd ../public && npm ci &&
+      - cd libs && npm ci --ignore-scripts &&
+        cd ../public && npm ci --ignore-scripts &&
         npm run start:public
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4300/public"]


### PR DESCRIPTION
The `ci --ignore-scripts` flag prevents pre-loading of npm scripts, which is the primary way Shai Hulud spreads.  This should ideally be used everywhere, although there are exceptions.

Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)
Fix: via @basilv

This is a follow up to #858, since there was more to patch.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-10.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-10.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-10.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)