### PR TITLE
fix: #865 Remove National Geographic Base Layer.

### DIFF
--- a/libs/utility/src/models/map-layers.ts
+++ b/libs/utility/src/models/map-layers.ts
@@ -19,10 +19,7 @@ export class MapLayers {
     
     this.createBaseLayer('Topographic', 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}', 
     'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community', 17);
-    
-    this.createBaseLayer('National Geographic', 'https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}',
-    'Tiles &copy; Esri &mdash; National Geographic, Esri, DeLorme, NAVTEQ, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA, iPC', 12);
-    
+ 
     this.createBaseLayer('BC Web Mercator', 'https://maps.gov.bc.ca/arcgis/rest/services/province/web_mercator_cache/MapServer/tile/{z}/{y}/{x}',
     'GeoBC, DataBC, TomTom, &copy; OpenStreetMap contributors', 17);
 


### PR DESCRIPTION
ref: #865 

- The National Geographic based layer is removed for both public/admin FOM based on FOM admin decision.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-19.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-19.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-19.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-19.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-19.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-19.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-19.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-19.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-19.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)