### PR TITLE
test: Jest unit tests for api, admin, and public

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -150,6 +150,6 @@ jobs:
             -p ZONE=${{ inputs.target }} 
             -p TAG=${{ needs.init.outputs.tag }}
             -p URL=${{ needs.init.outputs.url }}
-            ${{ matrix.name != 'db' && format('-p REPLICA_COUNT={0}', inputs.replica_count) }}
+            ${{ matrix.name != 'db' && format('-p REPLICA_COUNT={0}', inputs.replica_count) || '' }}
             ${{ matrix.parameters }}
           triggers: ${{ inputs.triggers }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -38,6 +38,10 @@ on:
         description: Deployment target; usually PR number, test or prod
         default: ${{ github.event.number }}
         type: string
+      replica_count:
+        description: Number of replicas for each component
+        default: 3
+        type: number
       triggers:
         description: Paths to check for changes
         type: string
@@ -146,5 +150,6 @@ jobs:
             -p ZONE=${{ inputs.target }} 
             -p TAG=${{ needs.init.outputs.tag }}
             -p URL=${{ needs.init.outputs.url }}
+            ${{ matrix.name != 'db' && format('-p REPLICA_COUNT={0}', inputs.replica_count) }}
             ${{ matrix.parameters }}
           triggers: ${{ inputs.triggers }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -16,8 +16,21 @@ concurrency:
 permissions: {}
 
 jobs:
-  tests:
-    name: Unit Tests
+  tests-admin:
+    name: Unit Tests (admin)
+    if: (! github.event.pull_request.draft)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: bcgov/action-test-and-analyse@v1.3.0
+        with:
+          commands: |
+            npm ci --ignore-scripts
+            npm run test-unit
+          dir: admin
+          node_version: 18.18.2
+
+  tests-api:
+    name: Unit Tests (api)
     if: (! github.event.pull_request.draft)
     runs-on: ubuntu-24.04
     steps:
@@ -34,6 +47,19 @@ jobs:
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.projectKey=nr-fom
           sonar_token: ${{ secrets.SONAR_TOKEN }}
+
+   tests-public:
+    name: Unit Tests (public)
+    if: (! github.event.pull_request.draft)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: bcgov/action-test-and-analyse@v1.3.0
+        with:
+          commands: |
+            npm ci --ignore-scripts
+            npm run test-unit
+          dir: public
+          node_version: 18.18.2
 
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:
@@ -62,7 +88,7 @@ jobs:
 
   results:
     name: Analysis Results
-    needs: [tests, trivy]
+    needs: [tests-api, trivy]
     if: always()
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           commands: |
             npm ci --ignore-scripts
-            ln -sf ../node_modules admin/node_modules
             npm run test-unit
           dir: admin
           node_version: 18.19.1
@@ -58,7 +57,6 @@ jobs:
         with:
           commands: |
             npm ci --ignore-scripts
-            ln -sf ../node_modules public/node_modules
             npm run test-unit
           dir: public
           node_version: 18.19.1

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -48,7 +48,7 @@ jobs:
             -Dsonar.projectKey=nr-fom
           sonar_token: ${{ secrets.SONAR_TOKEN }}
 
-   tests-public:
+  tests-public:
     name: Unit Tests (public)
     if: (! github.event.pull_request.draft)
     runs-on: ubuntu-24.04

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -27,7 +27,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: admin
-          node_version: 20.18.1
+          node_version: 18.19.1
 
   tests-api:
     name: Unit Tests (api)
@@ -40,7 +40,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: api
-          node_version: 20.18.1
+          node_version: 18.19.1
           sonar_args: >
             -Dsonar.exclusions=**/*.spec.ts
             -Dsonar.javascript.lcov.reportPaths=coverage/api/lcov.info   
@@ -59,7 +59,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: public
-          node_version: 20.18.1
+          node_version: 18.19.1
 
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: bcgov/action-test-and-analyse@v1.3.0
         with:
           commands: |
+            cd ../libs && npm ci --ignore-scripts && cd -
             npm ci --ignore-scripts
             npm run test-unit
           dir: admin
@@ -56,6 +57,7 @@ jobs:
       - uses: bcgov/action-test-and-analyse@v1.3.0
         with:
           commands: |
+            cd ../libs && npm ci --ignore-scripts && cd -
             npm ci --ignore-scripts
             npm run test-unit
           dir: public

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -90,7 +90,7 @@ jobs:
 
   results:
     name: Analysis Results
-    needs: [tests-api, trivy]
+    needs: [tests-admin, tests-api, tests-public, trivy]
     if: always()
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           commands: |
             npm ci --ignore-scripts
+            ln -sf ../node_modules admin/node_modules
             npm run test-unit
           dir: admin
           node_version: 18.19.1
@@ -57,6 +58,7 @@ jobs:
         with:
           commands: |
             npm ci --ignore-scripts
+            ln -sf ../node_modules public/node_modules
             npm run test-unit
           dir: public
           node_version: 18.19.1

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -27,7 +27,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: admin
-          node_version: 18.19.1
+          node_version: 20.18.1
 
   tests-api:
     name: Unit Tests (api)
@@ -40,7 +40,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: api
-          node_version: 18.19.1
+          node_version: 20.18.1
           sonar_args: >
             -Dsonar.exclusions=**/*.spec.ts
             -Dsonar.javascript.lcov.reportPaths=coverage/api/lcov.info   
@@ -59,7 +59,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: public
-          node_version: 18.19.1
+          node_version: 20.18.1
 
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           commands: |
             npm ci --ignore-scripts
+            ln -sf "$(pwd)/node_modules" "$(dirname "$(pwd)")/node_modules"
             npm run test-unit
           dir: admin
           node_version: 18.19.1
@@ -57,6 +58,7 @@ jobs:
         with:
           commands: |
             npm ci --ignore-scripts
+            ln -sf "$(pwd)/node_modules" "$(dirname "$(pwd)")/node_modules"
             npm run test-unit
           dir: public
           node_version: 18.19.1

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           commands: |
             npm ci --ignore-scripts
-            ln -sf "$(pwd)/node_modules" "$(dirname "$(pwd)")/node_modules"
             npm run test-unit
           dir: admin
           node_version: 18.19.1
@@ -58,7 +57,6 @@ jobs:
         with:
           commands: |
             npm ci --ignore-scripts
-            ln -sf "$(pwd)/node_modules" "$(dirname "$(pwd)")/node_modules"
             npm run test-unit
           dir: public
           node_version: 18.19.1

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -27,7 +27,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: admin
-          node_version: 18.18.2
+          node_version: 18.19.1
 
   tests-api:
     name: Unit Tests (api)
@@ -40,7 +40,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: api
-          node_version: 18.18.2
+          node_version: 18.19.1
           sonar_args: >
             -Dsonar.exclusions=**/*.spec.ts
             -Dsonar.javascript.lcov.reportPaths=coverage/api/lcov.info   
@@ -59,7 +59,7 @@ jobs:
             npm ci --ignore-scripts
             npm run test-unit
           dir: public
-          node_version: 18.18.2
+          node_version: 18.19.1
 
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -53,6 +53,7 @@ jobs:
     with:
       db_testdata: true
       email_notify: nonexistent@gov.bc.ca  # lower environment fake email address to send
+      replica_count: 1
       triggers: ('db/' 'libs/' 'api/' 'admin/' 'public/')
 
   results:

--- a/admin/jest.config.js
+++ b/admin/jest.config.js
@@ -11,7 +11,6 @@ module.exports = {
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',
     '^@utility/(.*)$': '<rootDir>/../libs/utility/src/$1',
     '^app/(.*)$': '<rootDir>/src/app/$1',
-    '^tslib$': '<rootDir>/node_modules/tslib',
   },
   coverageDirectory: '../coverage/admin',
   snapshotSerializers: [

--- a/admin/jest.config.js
+++ b/admin/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',
     '^@utility/(.*)$': '<rootDir>/../libs/utility/src/$1',
     '^app/(.*)$': '<rootDir>/src/app/$1',
+    '^tslib$': '<rootDir>/node_modules/tslib',
   },
   coverageDirectory: '../coverage/admin',
   snapshotSerializers: [

--- a/admin/jest.config.js
+++ b/admin/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '<rootDir>/src/**/*.spec.ts',
   ],
   roots: ['<rootDir>/src'],
+  moduleDirectories: ['node_modules', '<rootDir>/../libs/node_modules'],
   moduleNameMapper: {
     '^@admin-core/(.*)$': '<rootDir>/src/core/$1',
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',

--- a/admin/jest.config.js
+++ b/admin/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   testMatch: [
     '<rootDir>/src/**/*.spec.ts',
   ],
+  roots: ['<rootDir>/src'],
   moduleNameMapper: {
     '^@admin-core/(.*)$': '<rootDir>/src/core/$1',
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',

--- a/admin/jest.config.js
+++ b/admin/jest.config.js
@@ -6,8 +6,7 @@ module.exports = {
   testMatch: [
     '<rootDir>/src/**/*.spec.ts',
   ],
-  roots: ['<rootDir>/src'],
-  moduleDirectories: ['node_modules', '<rootDir>/../libs/node_modules'],
+  modulePaths: ['<rootDir>'],
   moduleNameMapper: {
     '^@admin-core/(.*)$': '<rootDir>/src/core/$1',
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',

--- a/admin/jest.config.js
+++ b/admin/jest.config.js
@@ -1,29 +1,21 @@
-const config = {
-  verbose: true,
-};
-
-module.exports = config;
-
 module.exports = {
   displayName: 'admin',
   preset: 'jest-preset-angular',
+  setupFiles: ['<rootDir>/src/jest-global-setup.ts'],
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.(html|svg)$',
-      astTransformers: {
-        before: [
-          'jest-preset-angular/build/InlineFilesTransformer',
-          'jest-preset-angular/build/StripStylesTransformer',
-        ],
-      },
-    },
+  testMatch: [
+    '<rootDir>/src/**/*.spec.ts',
+  ],
+  moduleNameMapper: {
+    '^@admin-core/(.*)$': '<rootDir>/src/core/$1',
+    '^@api-client$': '<rootDir>/../libs/client/typescript-ng',
+    '^@utility/(.*)$': '<rootDir>/../libs/utility/src/$1',
+    '^app/(.*)$': '<rootDir>/src/app/$1',
   },
   coverageDirectory: '../coverage/admin',
   snapshotSerializers: [
-    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
-    'jest-preset-angular/build/AngularSnapshotSerializer.js',
-    'jest-preset-angular/build/HTMLCommentSerializer.js',
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
   ],
 };

--- a/admin/package.json
+++ b/admin/package.json
@@ -4,7 +4,9 @@
   "license": "MIT",
   "scripts": {
     "start:admin": "ng serve --configuration development --host=0.0.0.0",
-    "build:admin": "ng build --configuration production"
+    "build:admin": "ng build --configuration production",
+    "test-unit": "jest --coverage",
+    "test-unit-watch": "jest --watch=true"
   },
   "private": true,
   "dependencies": {

--- a/admin/src/app/analytics-dashboard/analytics-dashboard-data.service.spec.ts
+++ b/admin/src/app/analytics-dashboard/analytics-dashboard-data.service.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { AnalyticsDashboardDataService } from './analytics-dashboard-data.service';
+import { AnalyticsDashboardService } from '@api-client';
+import { of, throwError } from 'rxjs';
+
+describe('AnalyticsDashboardDataService', () => {
+  let service: AnalyticsDashboardDataService;
+  let apiSpy: jasmine.SpyObj<AnalyticsDashboardService>;
+
+  beforeEach(() => {
+    const spy = jasmine.createSpyObj('AnalyticsDashboardService', [
+      'analyticsDashboardControllerGetNonInitialPublishedProjectCount',
+      'analyticsDashboardControllerGetCommentCountByResponseCode',
+      'analyticsDashboardControllerGetTopCommentedProjects',
+      'analyticsDashboardControllerGetCommentCountByDistrict',
+      'analyticsDashboardControllerGetNonInitialPublishedProjectCountByDistrict',
+      'analyticsDashboardControllerGetUniqueForestClientCount',
+      'analyticsDashboardControllerGetNonInitialPublishedProjectCountByForestClient',
+    ]);
+    TestBed.configureTestingModule({
+      providers: [
+        AnalyticsDashboardDataService,
+        { provide: AnalyticsDashboardService, useValue: spy },
+      ],
+    });
+    service = TestBed.inject(AnalyticsDashboardDataService);
+    apiSpy = TestBed.inject(AnalyticsDashboardService) as jasmine.SpyObj<AnalyticsDashboardService>;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  // Add more tests for getAnalyticsData and error handling here
+});

--- a/admin/src/app/analytics-dashboard/analytics-dashboard-data.service.spec.ts
+++ b/admin/src/app/analytics-dashboard/analytics-dashboard-data.service.spec.ts
@@ -1,35 +1,31 @@
 import { TestBed } from '@angular/core/testing';
 import { AnalyticsDashboardDataService } from './analytics-dashboard-data.service';
 import { AnalyticsDashboardService } from '@api-client';
-import { of, throwError } from 'rxjs';
 
 describe('AnalyticsDashboardDataService', () => {
   let service: AnalyticsDashboardDataService;
-  let apiSpy: jasmine.SpyObj<AnalyticsDashboardService>;
+  let apiMock: jest.Mocked<AnalyticsDashboardService>;
 
   beforeEach(() => {
-    const spy = jasmine.createSpyObj('AnalyticsDashboardService', [
-      'analyticsDashboardControllerGetNonInitialPublishedProjectCount',
-      'analyticsDashboardControllerGetCommentCountByResponseCode',
-      'analyticsDashboardControllerGetTopCommentedProjects',
-      'analyticsDashboardControllerGetCommentCountByDistrict',
-      'analyticsDashboardControllerGetNonInitialPublishedProjectCountByDistrict',
-      'analyticsDashboardControllerGetUniqueForestClientCount',
-      'analyticsDashboardControllerGetNonInitialPublishedProjectCountByForestClient',
-    ]);
+    apiMock = {
+      analyticsDashboardControllerGetNonInitialPublishedProjectCount: jest.fn(),
+      analyticsDashboardControllerGetCommentCountByResponseCode: jest.fn(),
+      analyticsDashboardControllerGetTopCommentedProjects: jest.fn(),
+      analyticsDashboardControllerGetCommentCountByDistrict: jest.fn(),
+      analyticsDashboardControllerGetNonInitialPublishedProjectCountByDistrict: jest.fn(),
+      analyticsDashboardControllerGetUniqueForestClientCount: jest.fn(),
+      analyticsDashboardControllerGetNonInitialPublishedProjectCountByForestClient: jest.fn(),
+    } as any;
     TestBed.configureTestingModule({
       providers: [
         AnalyticsDashboardDataService,
-        { provide: AnalyticsDashboardService, useValue: spy },
+        { provide: AnalyticsDashboardService, useValue: apiMock },
       ],
     });
     service = TestBed.inject(AnalyticsDashboardDataService);
-    apiSpy = TestBed.inject(AnalyticsDashboardService) as jasmine.SpyObj<AnalyticsDashboardService>;
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
-
-  // Add more tests for getAnalyticsData and error handling here
 });

--- a/admin/src/app/foms/fom-submission/fom-submission.component.spec.ts
+++ b/admin/src/app/foms/fom-submission/fom-submission.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FomSubmissionComponent } from './fom-submission.component';
 import { CognitoService } from '@admin-core/services/cognito.service';
@@ -19,10 +19,10 @@ describe('FomSubmissionComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         FomSubmissionComponent,
-        RouterTestingModule,
         NoopAnimationsModule,
       ],
       providers: [
+        provideRouter([]),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/admin/src/app/foms/fom-submission/fom-submission.component.spec.ts
+++ b/admin/src/app/foms/fom-submission/fom-submission.component.spec.ts
@@ -1,6 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FomSubmissionComponent } from './fom-submission.component';
+import { CognitoService } from '@admin-core/services/cognito.service';
+import { ModalService } from '@admin-core/services/modal.service';
+import { StateService } from '@admin-core/services/state.service';
+import { ActivatedRoute } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { RxFormBuilder } from '@rxweb/reactive-form-validators';
+import { ProjectService, SubmissionService } from '@api-client';
+import { of } from 'rxjs';
 
 describe('FomSubmissionComponent', () => {
   let component: FomSubmissionComponent;
@@ -8,7 +17,27 @@ describe('FomSubmissionComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ FomSubmissionComponent ]
+      imports: [
+        FomSubmissionComponent,
+        RouterTestingModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { appId: '1' } },
+            url: of([]),
+          },
+        },
+        { provide: ProjectService, useValue: { projectControllerFindOne: jest.fn().mockReturnValue(of({})) } },
+        { provide: SubmissionService, useValue: { submissionControllerFindSubmissionDetailForCurrentSubmissionType: jest.fn().mockReturnValue(of({})) } },
+        { provide: StateService, useValue: { loading: false } },
+        { provide: ModalService, useValue: { openErrorDialog: jest.fn(), openConfirmationDialog: jest.fn() } },
+        { provide: CognitoService, useValue: { getUser: jest.fn().mockReturnValue({ isAuthorizedForClientId: jest.fn() }) } },
+        { provide: RxFormBuilder, useValue: { formGroup: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue({ setValue: jest.fn() }), value: {} }) } },
+        MatSnackBar,
+      ],
     })
     .compileComponents();
   });
@@ -16,7 +45,6 @@ describe('FomSubmissionComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(FomSubmissionComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {

--- a/admin/src/app/foms/fom-submission/fom-submission.component.spec.ts
+++ b/admin/src/app/foms/fom-submission/fom-submission.component.spec.ts
@@ -36,7 +36,7 @@ describe('FomSubmissionComponent', () => {
         { provide: ModalService, useValue: { openErrorDialog: jest.fn(), openConfirmationDialog: jest.fn() } },
         { provide: CognitoService, useValue: { getUser: jest.fn().mockReturnValue({ isAuthorizedForClientId: jest.fn() }) } },
         { provide: RxFormBuilder, useValue: { formGroup: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue({ setValue: jest.fn() }), value: {} }) } },
-        MatSnackBar,
+        { provide: MatSnackBar, useValue: { open: jest.fn(), dismiss: jest.fn() } },
       ],
     })
     .compileComponents();

--- a/admin/src/app/foms/fom.resolvers.spec.ts
+++ b/admin/src/app/foms/fom.resolvers.spec.ts
@@ -2,39 +2,47 @@ import { TestBed } from '@angular/core/testing';
 import { projectDetailResolver, projectMetricsDetailResolver, projectSpatialDetailResolver } from './fom.resolvers';
 import { ProjectService, SpatialFeatureService } from '@api-client';
 import { of } from 'rxjs';
+import { ActivatedRouteSnapshot } from '@angular/router';
 
 describe('FOM Resolvers', () => {
-  let projectServiceSpy: jasmine.SpyObj<ProjectService>;
-  let spatialFeatureServiceSpy: jasmine.SpyObj<SpatialFeatureService>;
+  let projectServiceMock: jest.Mocked<ProjectService>;
+  let spatialFeatureServiceMock: jest.Mocked<SpatialFeatureService>;
 
   beforeEach(() => {
-    projectServiceSpy = jasmine.createSpyObj('ProjectService', [
-      'projectControllerFindOne',
-      'projectControllerFindProjectMetrics',
-    ]);
-    spatialFeatureServiceSpy = jasmine.createSpyObj('SpatialFeatureService', [
-      'spatialFeatureControllerGetForProject',
-    ]);
+    projectServiceMock = {
+      projectControllerFindOne: jest.fn(),
+      projectControllerFindProjectMetrics: jest.fn(),
+    } as any;
+    spatialFeatureServiceMock = {
+      spatialFeatureControllerGetForProject: jest.fn(),
+    } as any;
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ProjectService, useValue: projectServiceMock },
+        { provide: SpatialFeatureService, useValue: spatialFeatureServiceMock },
+      ],
+    });
   });
 
   it('should resolve project details', () => {
-    const route: any = { paramMap: { get: () => '1' } };
-    projectServiceSpy.projectControllerFindOne.and.returnValue(of({ id: 1 }));
-    const result = projectDetailResolver(route, null);
+    projectServiceMock.projectControllerFindOne.mockReturnValue(of({ id: 1 }) as any);
+    const route = { paramMap: { get: () => '1' } } as any as ActivatedRouteSnapshot;
+    const result = TestBed.runInInjectionContext(() => projectDetailResolver(route, null));
     expect(result).toBeDefined();
   });
 
   it('should resolve project metrics', () => {
-    const route: any = { paramMap: { get: () => '1' } };
-    projectServiceSpy.projectControllerFindProjectMetrics.and.returnValue(of({ metrics: true }));
-    const result = projectMetricsDetailResolver(route, null);
+    projectServiceMock.projectControllerFindProjectMetrics.mockReturnValue(of({ metrics: true }) as any);
+    const route = { paramMap: { get: () => '1' } } as any as ActivatedRouteSnapshot;
+    const result = TestBed.runInInjectionContext(() => projectMetricsDetailResolver(route, null));
     expect(result).toBeDefined();
   });
 
   it('should resolve project spatial details', () => {
-    const route: any = { paramMap: { get: () => '1' } };
-    spatialFeatureServiceSpy.spatialFeatureControllerGetForProject.and.returnValue(of([ { id: 1 } ]));
-    const result = projectSpatialDetailResolver(route, null);
+    spatialFeatureServiceMock.spatialFeatureControllerGetForProject.mockReturnValue(of([{ id: 1 }]) as any);
+    const route = { paramMap: { get: () => '1' } } as any as ActivatedRouteSnapshot;
+    const result = TestBed.runInInjectionContext(() => projectSpatialDetailResolver(route, null));
     expect(result).toBeDefined();
   });
 });

--- a/admin/src/app/foms/fom.resolvers.spec.ts
+++ b/admin/src/app/foms/fom.resolvers.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { projectDetailResolver, projectMetricsDetailResolver, projectSpatialDetailResolver } from './fom.resolvers';
+import { ProjectService, SpatialFeatureService } from '@api-client';
+import { of } from 'rxjs';
+
+describe('FOM Resolvers', () => {
+  let projectServiceSpy: jasmine.SpyObj<ProjectService>;
+  let spatialFeatureServiceSpy: jasmine.SpyObj<SpatialFeatureService>;
+
+  beforeEach(() => {
+    projectServiceSpy = jasmine.createSpyObj('ProjectService', [
+      'projectControllerFindOne',
+      'projectControllerFindProjectMetrics',
+    ]);
+    spatialFeatureServiceSpy = jasmine.createSpyObj('SpatialFeatureService', [
+      'spatialFeatureControllerGetForProject',
+    ]);
+  });
+
+  it('should resolve project details', () => {
+    const route: any = { paramMap: { get: () => '1' } };
+    projectServiceSpy.projectControllerFindOne.and.returnValue(of({ id: 1 }));
+    const result = projectDetailResolver(route, null);
+    expect(result).toBeDefined();
+  });
+
+  it('should resolve project metrics', () => {
+    const route: any = { paramMap: { get: () => '1' } };
+    projectServiceSpy.projectControllerFindProjectMetrics.and.returnValue(of({ metrics: true }));
+    const result = projectMetricsDetailResolver(route, null);
+    expect(result).toBeDefined();
+  });
+
+  it('should resolve project spatial details', () => {
+    const route: any = { paramMap: { get: () => '1' } };
+    spatialFeatureServiceSpy.spatialFeatureControllerGetForProject.and.returnValue(of([ { id: 1 } ]));
+    const result = projectSpatialDetailResolver(route, null);
+    expect(result).toBeDefined();
+  });
+});

--- a/admin/src/app/spec/helpers.spec.ts
+++ b/admin/src/app/spec/helpers.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteStub } from './helpers';
+
+describe('ActivatedRouteStub', () => {
+  it('should create an instance', () => {
+    const stub = new ActivatedRouteStub();
+    expect(stub).toBeTruthy();
+  });
+
+  it('should set data', () => {
+    const stub = new ActivatedRouteStub();
+    stub.setData({ foo: 'bar' });
+    stub.data.subscribe(data => {
+      expect(data.foo).toBe('bar');
+    });
+  });
+
+  it('should set params', () => {
+    const stub = new ActivatedRouteStub();
+    stub.setParams({ id: 123 });
+    stub.params.subscribe(params => {
+      expect(params.id).toBe(123);
+    });
+  });
+});

--- a/admin/src/app/spec/helpers.spec.ts
+++ b/admin/src/app/spec/helpers.spec.ts
@@ -1,4 +1,3 @@
-import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteStub } from './helpers';
 
 describe('ActivatedRouteStub', () => {
@@ -10,7 +9,7 @@ describe('ActivatedRouteStub', () => {
   it('should set data', () => {
     const stub = new ActivatedRouteStub();
     stub.setData({ foo: 'bar' });
-    stub.data.subscribe(data => {
+    stub.data.subscribe((data: any) => {
       expect(data.foo).toBe('bar');
     });
   });
@@ -18,7 +17,7 @@ describe('ActivatedRouteStub', () => {
   it('should set params', () => {
     const stub = new ActivatedRouteStub();
     stub.setParams({ id: 123 });
-    stub.params.subscribe(params => {
+    stub.params.subscribe((params: any) => {
       expect(params.id).toBe(123);
     });
   });

--- a/admin/src/core/services/state.service.spec.ts
+++ b/admin/src/core/services/state.service.spec.ts
@@ -1,16 +1,63 @@
 import { TestBed } from '@angular/core/testing';
-
 import { StateService } from './state.service';
+import { DistrictService, PublicCommentService, ProjectService } from '@api-client';
 
 describe('StateService', () => {
   let service: StateService;
+  let mockPublicCommentService: Partial<PublicCommentService>;
+  let mockDistrictService: Partial<DistrictService>;
+  let mockProjectService: Partial<ProjectService>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    mockPublicCommentService = {
+      responseCodeControllerFindAll: jest.fn(),
+      commentScopeCodeControllerFindAll: jest.fn(),
+    };
+    mockDistrictService = {
+      districtControllerFindAll: jest.fn(),
+    };
+    mockProjectService = {
+      workflowStateCodeControllerFindAll: jest.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        StateService,
+        { provide: PublicCommentService, useValue: mockPublicCommentService },
+        { provide: DistrictService, useValue: mockDistrictService },
+        { provide: ProjectService, useValue: mockProjectService },
+      ],
+    });
     service = TestBed.inject(StateService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should start as not ready', () => {
+    const spy = jest.fn();
+    service.isReady$.subscribe(spy);
+    expect(spy).toHaveBeenCalledWith(false);
+  });
+
+  it('should set ready', () => {
+    const spy = jest.fn();
+    service.isReady$.subscribe(spy);
+    service.setReady();
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('should set and get code tables', () => {
+    const tables = { responseCode: [], district: [] } as any;
+    service.setCodeTables(tables);
+    expect(service.codeTables).toBe(tables);
+  });
+
+  it('should set and get loading state', () => {
+    service.loading = true;
+    expect(service.loading).toBe(true);
+    service.loading = false;
+    expect(service.loading).toBe(false);
   });
 });

--- a/admin/src/jest-global-setup.ts
+++ b/admin/src/jest-global-setup.ts
@@ -1,0 +1,6 @@
+// This file runs BEFORE jest-preset-angular is loaded.
+// It patches the Buffer prototype chain to fix esbuild's instanceof check
+// in Jest's VM context (Node.js 22 compatibility).
+if (!(Buffer.from('') instanceof Uint8Array)) {
+  Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype);
+}

--- a/admin/src/test-setup.ts
+++ b/admin/src/test-setup.ts
@@ -1,1 +1,9 @@
-import 'jest-preset-angular';
+import 'zone.js';
+import 'zone.js/testing';
+import { TestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+TestBed.initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/admin/src/test-setup.ts
+++ b/admin/src/test-setup.ts
@@ -1,8 +1,3 @@
-import 'zone.js';
-import { TestBed } from '@angular/core/testing';
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 
-TestBed.initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+setupZoneTestEnv();

--- a/admin/src/test-setup.ts
+++ b/admin/src/test-setup.ts
@@ -1,5 +1,4 @@
 import 'zone.js';
-import 'zone.js/testing';
 import { TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 

--- a/admin/tsconfig.json
+++ b/admin/tsconfig.json
@@ -33,9 +33,10 @@
         "../node_modules/@angular/*"
       ]
     },
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "types": ["jest", "node"]
   },
-  "exclude": ["node_modules", "**/*.spec.ts"],
+  "exclude": ["node_modules"],
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,

--- a/admin/tsconfig.spec.json
+++ b/admin/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist/admin/spec",
     "module": "commonjs",
-    "types": ["jest", "node"],
+    "types": ["jest", "node", "zone.js"],
     "importHelpers": false
   },
   "files": ["src/test-setup.ts"],

--- a/admin/tsconfig.spec.json
+++ b/admin/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist/admin/spec",
     "module": "commonjs",
-    "types": ["jest", "node", "zone.js"],
+    "types": ["jest", "node"],
     "importHelpers": false
   },
   "files": ["src/test-setup.ts"],

--- a/admin/tsconfig.spec.json
+++ b/admin/tsconfig.spec.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "outDir": "dist/admin/spec",
     "module": "commonjs",
-    "types": ["jest", "node"],
-    "importHelpers": false
+    "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/admin/tsconfig.spec.json
+++ b/admin/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist/admin/spec",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "importHelpers": false
   },
   "files": ["src/test-setup.ts"],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/api/src/app/modules/district/district.service.spec.ts
+++ b/api/src/app/modules/district/district.service.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DistrictService } from './district.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { District } from './district.entity';
+import { PinoLogger } from 'nestjs-pino';
+import { Repository } from 'typeorm';
+
+describe('DistrictService', () => {
+  let service: DistrictService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DistrictService,
+        { provide: getRepositoryToken(District), useValue: {} },
+        { provide: PinoLogger, useValue: { debug: jest.fn(), setContext: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<DistrictService>(DistrictService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // Add more tests for convertEntity, etc.
+});

--- a/api/src/app/modules/spatial-feature/spatial-feature.service.spec.ts
+++ b/api/src/app/modules/spatial-feature/spatial-feature.service.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SpatialFeatureService } from './spatial-feature.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SpatialFeature } from './spatial-feature.entity';
+import { PinoLogger } from 'nestjs-pino';
+import { Repository } from 'typeorm';
+
+describe('SpatialFeatureService', () => {
+  let service: SpatialFeatureService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SpatialFeatureService,
+        { provide: getRepositoryToken(SpatialFeature), useValue: {} },
+        { provide: PinoLogger, useValue: { debug: jest.fn(), setContext: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<SpatialFeatureService>(SpatialFeatureService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // Add more tests for service methods here
+});

--- a/api/src/core/utils.spec.ts
+++ b/api/src/core/utils.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { flatDeep } from '../../core/utils';
+import { flatDeep } from './utils';
 
 describe('flatDeep', () => {
   it('should flatten nested arrays', () => {

--- a/api/src/core/utils.spec.ts
+++ b/api/src/core/utils.spec.ts
@@ -4,7 +4,7 @@ import { flatDeep } from './utils';
 describe('flatDeep', () => {
   it('should flatten nested arrays', () => {
     const arr = [ 1, [ 2, [ 3, [ 4 ] ], 5 ] ];
-    expect(flatDeep(arr)).toEqual([ 1, 2, 3, 4, 5 ]);
+    expect(flatDeep(arr, 10)).toEqual([ 1, 2, 3, 4, 5 ]);
   });
 
   it('should return empty array if input is empty', () => {

--- a/api/src/core/utils.spec.ts
+++ b/api/src/core/utils.spec.ts
@@ -1,17 +1,22 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { flatDeep } from './utils';
 
 describe('flatDeep', () => {
-  it('should flatten nested arrays', () => {
+  it('should flatten nested arrays with sufficient depth', () => {
     const arr = [ 1, [ 2, [ 3, [ 4 ] ], 5 ] ];
     expect(flatDeep(arr, 10)).toEqual([ 1, 2, 3, 4, 5 ]);
+  });
+
+  it('should flatten one level by default', () => {
+    const arr = [ 1, [ 2, 3 ], [ 4, [ 5 ] ] ];
+    expect(flatDeep(arr)).toEqual([ 1, 2, 3, 4, [ 5 ] ]);
   });
 
   it('should return empty array if input is empty', () => {
     expect(flatDeep([])).toEqual([]);
   });
 
-  it('should handle non-array input', () => {
-    expect(flatDeep(1)).toEqual([ 1 ]);
+  it('should return shallow copy when depth is 0', () => {
+    const arr = [ 1, [ 2, [ 3 ] ] ];
+    expect(flatDeep(arr, 0)).toEqual([ 1, [ 2, [ 3 ] ] ]);
   });
 });

--- a/api/src/core/utils.spec.ts
+++ b/api/src/core/utils.spec.ts
@@ -1,0 +1,17 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { flatDeep } from '../../core/utils';
+
+describe('flatDeep', () => {
+  it('should flatten nested arrays', () => {
+    const arr = [ 1, [ 2, [ 3, [ 4 ] ], 5 ] ];
+    expect(flatDeep(arr)).toEqual([ 1, 2, 3, 4, 5 ]);
+  });
+
+  it('should return empty array if input is empty', () => {
+    expect(flatDeep([])).toEqual([]);
+  });
+
+  it('should handle non-array input', () => {
+    expect(flatDeep(1)).toEqual([ 1 ]);
+  });
+});

--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist"
+  ]
 }

--- a/public/jest.config.js
+++ b/public/jest.config.js
@@ -11,7 +11,6 @@ module.exports = {
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',
     '^@utility/(.*)$': '<rootDir>/../libs/utility/src/$1',
     '^app/(.*)$': '<rootDir>/src/app/$1',
-    '^tslib$': '<rootDir>/node_modules/tslib',
   },
   coverageDirectory: '../coverage/public',
   snapshotSerializers: [

--- a/public/jest.config.js
+++ b/public/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '<rootDir>/src/**/*.spec.ts',
   ],
   roots: ['<rootDir>/src'],
+  moduleDirectories: ['node_modules', '<rootDir>/../libs/node_modules'],
   moduleNameMapper: {
     '^@public-core/(.*)$': '<rootDir>/src/core/$1',
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',

--- a/public/jest.config.js
+++ b/public/jest.config.js
@@ -6,8 +6,7 @@ module.exports = {
   testMatch: [
     '<rootDir>/src/**/*.spec.ts',
   ],
-  roots: ['<rootDir>/src'],
-  moduleDirectories: ['node_modules', '<rootDir>/../libs/node_modules'],
+  modulePaths: ['<rootDir>'],
   moduleNameMapper: {
     '^@public-core/(.*)$': '<rootDir>/src/core/$1',
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',

--- a/public/jest.config.js
+++ b/public/jest.config.js
@@ -1,27 +1,21 @@
 module.exports = {
   displayName: 'public',
   preset: 'jest-preset-angular',
+  setupFiles: ['<rootDir>/src/jest-global-setup.ts'],
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.(html|svg)$',
-      astTransformers: {
-        before: [
-          'jest-preset-angular/build/InlineFilesTransformer',
-          'jest-preset-angular/build/StripStylesTransformer',
-        ],
-      },
-    },
-  },
   testMatch: [
     '<rootDir>/src/**/*.spec.ts',
-    '<rootDir>/src/app/**/*.spec.ts',
   ],
+  moduleNameMapper: {
+    '^@public-core/(.*)$': '<rootDir>/src/core/$1',
+    '^@api-client$': '<rootDir>/../libs/client/typescript-ng',
+    '^@utility/(.*)$': '<rootDir>/../libs/utility/src/$1',
+    '^app/(.*)$': '<rootDir>/src/app/$1',
+  },
   coverageDirectory: '../coverage/public',
   snapshotSerializers: [
-    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
-    'jest-preset-angular/build/AngularSnapshotSerializer.js',
-    'jest-preset-angular/build/HTMLCommentSerializer.js',
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
   ],
 };

--- a/public/jest.config.js
+++ b/public/jest.config.js
@@ -14,6 +14,10 @@ module.exports = {
       },
     },
   },
+  testMatch: [
+    '<rootDir>/src/**/*.spec.ts',
+    '<rootDir>/src/app/**/*.spec.ts',
+  ],
   coverageDirectory: '../coverage/public',
   snapshotSerializers: [
     'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',

--- a/public/jest.config.js
+++ b/public/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',
     '^@utility/(.*)$': '<rootDir>/../libs/utility/src/$1',
     '^app/(.*)$': '<rootDir>/src/app/$1',
+    '^tslib$': '<rootDir>/node_modules/tslib',
   },
   coverageDirectory: '../coverage/public',
   snapshotSerializers: [

--- a/public/jest.config.js
+++ b/public/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   testMatch: [
     '<rootDir>/src/**/*.spec.ts',
   ],
+  roots: ['<rootDir>/src'],
   moduleNameMapper: {
     '^@public-core/(.*)$': '<rootDir>/src/core/$1',
     '^@api-client$': '<rootDir>/../libs/client/typescript-ng',

--- a/public/package.json
+++ b/public/package.json
@@ -4,7 +4,9 @@
   "license": "MIT",
   "scripts": {
     "start:public": "ng serve --configuration development --host=0.0.0.0",
-    "build:public": "ng build --configuration production"
+    "build:public": "ng build --configuration production",
+    "test-unit": "jest --coverage",
+    "test-unit-watch": "jest --watch=true"
   },
   "private": true,
   "dependencies": {

--- a/public/src/app/about/about.component.spec.ts
+++ b/public/src/app/about/about.component.spec.ts
@@ -7,7 +7,7 @@ describe('AboutComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AboutComponent],
+      declarations: [ AboutComponent ],
     }).compileComponents();
     fixture = TestBed.createComponent(AboutComponent);
     component = fixture.componentInstance;

--- a/public/src/app/about/about.component.spec.ts
+++ b/public/src/app/about/about.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AboutComponent } from './about.component';
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -7,7 +8,7 @@ describe('AboutComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ AboutComponent ],
+      imports: [AboutComponent],
     }).compileComponents();
     fixture = TestBed.createComponent(AboutComponent);
     component = fixture.componentInstance;
@@ -18,5 +19,19 @@ describe('AboutComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should have faArrowUpRightFromSquare icon defined', () => {
+    expect(component.faArrowUpRightFromSquare).toBeDefined();
+    expect(component.faArrowUpRightFromSquare).toBe(faArrowUpRightFromSquare);
+  });
+
+  it('should have icon with expected properties', () => {
+    const icon = component.faArrowUpRightFromSquare;
+    expect(icon.iconName).toBe('arrow-up-right-from-square');
+    expect(icon.prefix).toBe('fas');
+  });
+
+  it('should render the about template', () => {
+    const el = fixture.nativeElement;
+    expect(el).toBeTruthy();
+  });
 });

--- a/public/src/app/about/about.component.spec.ts
+++ b/public/src/app/about/about.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AboutComponent } from './about.component';
+
+describe('AboutComponent', () => {
+  let component: AboutComponent;
+  let fixture: ComponentFixture<AboutComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AboutComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(AboutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/app.component.spec.ts
+++ b/public/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router, provideRouter } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { AppComponent } from './app.component';

--- a/public/src/app/app.component.spec.ts
+++ b/public/src/app/app.component.spec.ts
@@ -1,22 +1,95 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 import { AppComponent } from './app.component';
+import { StateService } from '@public-core/services/state.service';
+import { ModalService } from '@public-core/services/modal.service';
 
 describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
+  let mockStateService: Partial<StateService>;
+  let mockModalService: Partial<ModalService>;
 
   beforeEach(async () => {
+    mockStateService = {
+      getCodeTables: jest.fn().mockReturnValue(of({
+        responseCode: [],
+        district: [],
+        workflowStateCode: [],
+      })),
+      setCodeTables: jest.fn(),
+      setReady: jest.fn(),
+      isReady$: new BehaviorSubject<boolean>(false).asObservable(),
+    };
+
+    mockModalService = {
+      showFOMinitFailure: jest.fn(),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ AppComponent ],
+      imports: [AppComponent, RouterTestingModule],
+      providers: [
+        { provide: StateService, useValue: mockStateService },
+        { provide: ModalService, useValue: mockModalService },
+        provideNoopAnimations(),
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(AppComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('should create the app', () => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for component logic, template, and events as needed
+  it('should call getCodeTables on init', async () => {
+    await component.ngOnInit();
+    expect(mockStateService.getCodeTables).toHaveBeenCalled();
+  });
+
+  it('should set code tables after fetching', async () => {
+    const mockCodeTables = { responseCode: [], district: [], workflowStateCode: [] };
+    (mockStateService.getCodeTables as jest.Mock).mockReturnValue(of(mockCodeTables));
+    await component.ngOnInit();
+    expect(mockStateService.setCodeTables).toHaveBeenCalledWith(mockCodeTables);
+  });
+
+  it('should call setReady after loading code tables', async () => {
+    await component.ngOnInit();
+    expect(mockStateService.setReady).toHaveBeenCalled();
+  });
+
+  it('should show modal on init failure', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    (mockStateService.getCodeTables as jest.Mock).mockReturnValue(
+      throwError(() => new Error('init failed'))
+    );
+    await component.ngOnInit();
+    expect(mockModalService.showFOMinitFailure).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('should unsubscribe on destroy', () => {
+    const nextSpy = jest.spyOn(component['ngUnsubscribe'], 'next');
+    const completeSpy = jest.spyOn(component['ngUnsubscribe'], 'complete');
+    component.ngOnDestroy();
+    expect(nextSpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
+  });
+
+  it('should have header and footer components in template', () => {
+    fixture.detectChanges();
+    const el = fixture.nativeElement;
+    expect(el.querySelector('app-header')).toBeTruthy();
+    expect(el.querySelector('app-footer')).toBeTruthy();
+  });
+
+  it('should have router-outlet', () => {
+    fixture.detectChanges();
+    const el = fixture.nativeElement;
+    expect(el.querySelector('router-outlet')).toBeTruthy();
+  });
 });

--- a/public/src/app/app.component.spec.ts
+++ b/public/src/app/app.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  let component: AppComponent;
+  let fixture: ComponentFixture<AppComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AppComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the app', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for component logic, template, and events as needed
+});

--- a/public/src/app/app.component.spec.ts
+++ b/public/src/app/app.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { AppComponent } from './app.component';
@@ -30,8 +29,9 @@ describe('AppComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [AppComponent, RouterTestingModule],
+      imports: [AppComponent],
       providers: [
+        provideRouter([]),
         { provide: StateService, useValue: mockStateService },
         { provide: ModalService, useValue: mockModalService },
         provideNoopAnimations(),

--- a/public/src/app/applications-proxy.component.spec.ts
+++ b/public/src/app/applications-proxy.component.spec.ts
@@ -1,22 +1,50 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ApplicationsProxyComponent } from './applications-proxy.component';
 
 describe('ApplicationsProxyComponent', () => {
   let component: ApplicationsProxyComponent;
   let fixture: ComponentFixture<ApplicationsProxyComponent>;
+  let router: Router;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ApplicationsProxyComponent ],
+      imports: [ApplicationsProxyComponent, RouterTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: { id: '123' },
+            },
+          },
+        },
+      ],
     }).compileComponents();
+
+    router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate');
     fixture = TestBed.createComponent(ApplicationsProxyComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should navigate to /applications with id query param and details fragment', () => {
+    fixture.detectChanges();
+    expect(router.navigate).toHaveBeenCalledWith(
+      ['/applications'],
+      { queryParams: { id: '123' }, fragment: 'details' }
+    );
+  });
+
+  it('should pass route id to query params', () => {
+    fixture.detectChanges();
+    const navigateCall = (router.navigate as jest.Mock).mock.calls[0];
+    expect(navigateCall[1].queryParams.id).toBe('123');
+    expect(navigateCall[1].fragment).toBe('details');
+  });
 });

--- a/public/src/app/applications-proxy.component.spec.ts
+++ b/public/src/app/applications-proxy.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ApplicationsProxyComponent } from './applications-proxy.component';
+
+describe('ApplicationsProxyComponent', () => {
+  let component: ApplicationsProxyComponent;
+  let fixture: ComponentFixture<ApplicationsProxyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ApplicationsProxyComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ApplicationsProxyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications-proxy.component.spec.ts
+++ b/public/src/app/applications-proxy.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router, ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, ActivatedRoute, provideRouter } from '@angular/router';
 import { ApplicationsProxyComponent } from './applications-proxy.component';
 
 describe('ApplicationsProxyComponent', () => {
@@ -10,8 +9,9 @@ describe('ApplicationsProxyComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ApplicationsProxyComponent, RouterTestingModule],
+      imports: [ApplicationsProxyComponent],
       providers: [
+        provideRouter([]),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/public/src/app/applications/app-map/app-map.component.spec.ts
+++ b/public/src/app/applications/app-map/app-map.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { AppMapComponent } from './app-map.component';
 import { UrlService } from '@public-core/services/url.service';
 import { MapLayersService } from '@public-core/services/mapLayers.service';
@@ -38,8 +38,9 @@ describe('AppMapComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [AppMapComponent, RouterTestingModule],
+      imports: [AppMapComponent],
       providers: [
+        provideRouter([]),
         { provide: UrlService, useValue: mockUrlService },
         { provide: MapLayersService, useValue: mockMapLayersService },
       ],

--- a/public/src/app/applications/app-map/app-map.component.spec.ts
+++ b/public/src/app/applications/app-map/app-map.component.spec.ts
@@ -1,22 +1,95 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { AppMapComponent } from './app-map.component';
+import { UrlService } from '@public-core/services/url.service';
+import { MapLayersService } from '@public-core/services/mapLayers.service';
+
+// Mock leaflet.markercluster globally
+jest.mock('leaflet.markercluster', () => ({}), { virtual: true });
+
+// Mock leaflet to provide markerClusterGroup
+jest.mock('leaflet', () => {
+  const actual = jest.requireActual('leaflet');
+  return {
+    ...actual,
+    markerClusterGroup: jest.fn().mockReturnValue({
+      addLayer: jest.fn(),
+      removeLayer: jest.fn(),
+    }),
+    icon: jest.fn().mockReturnValue({}),
+  };
+});
 
 describe('AppMapComponent', () => {
   let component: AppMapComponent;
   let fixture: ComponentFixture<AppMapComponent>;
+  let mockUrlService: Partial<UrlService>;
+  let mockMapLayersService: Partial<MapLayersService>;
 
   beforeEach(async () => {
+    mockUrlService = {
+      getQueryParam: jest.fn().mockReturnValue(null),
+    };
+
+    mockMapLayersService = {
+      $mapLayersChange: { subscribe: jest.fn() } as any,
+      notifyLayersChange: jest.fn(),
+      mapLayersUpdate: jest.fn(),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ AppMapComponent ],
+      imports: [AppMapComponent, RouterTestingModule],
+      providers: [
+        { provide: UrlService, useValue: mockUrlService },
+        { provide: MapLayersService, useValue: mockMapLayersService },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(AppMapComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should have defaultBounds defined', () => {
+    expect(component.defaultBounds).toBeDefined();
+  });
+
+  it('should have projectPlanCodeEnum', () => {
+    expect(component.projectPlanCodeEnum).toBeDefined();
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should not throw when map is null', () => {
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
+
+    it('should unsubscribe', () => {
+      const nextSpy = jest.spyOn(component['ngUnsubscribe'], 'next');
+      const completeSpy = jest.spyOn(component['ngUnsubscribe'], 'complete');
+      component.ngOnDestroy();
+      expect(nextSpy).toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('unhighlightApplications', () => {
+    it('should not throw when currentMarker is null', () => {
+      expect(() => component.unhighlightApplications()).not.toThrow();
+    });
+  });
+
+  describe('input properties', () => {
+    it('should accept loading input', () => {
+      component.loading = true;
+      expect(component.loading).toBe(true);
+    });
+
+    it('should accept projectsSummary input', () => {
+      const summary = [{ id: 1, name: 'Project 1' }] as any;
+      component.projectsSummary = summary;
+      expect(component.projectsSummary).toBe(summary);
+    });
+  });
 });

--- a/public/src/app/applications/app-map/app-map.component.spec.ts
+++ b/public/src/app/applications/app-map/app-map.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AppMapComponent } from './app-map.component';
+
+describe('AppMapComponent', () => {
+  let component: AppMapComponent;
+  let fixture: ComponentFixture<AppMapComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AppMapComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(AppMapComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/app-map/marker-popup/marker-popup.component.spec.ts
+++ b/public/src/app/applications/app-map/marker-popup/marker-popup.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MarkerPopupComponent } from './marker-popup.component';
+
+describe('MarkerPopupComponent', () => {
+  let component: MarkerPopupComponent;
+  let fixture: ComponentFixture<MarkerPopupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MarkerPopupComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(MarkerPopupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/app-map/marker-popup/marker-popup.component.spec.ts
+++ b/public/src/app/applications/app-map/marker-popup/marker-popup.component.spec.ts
@@ -1,22 +1,73 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MarkerPopupComponent } from './marker-popup.component';
+import { StateService } from '@public-core/services/state.service';
+import { UrlService } from '@public-core/services/url.service';
+import { Panel } from '../../../applications/utils/panel.enum';
 
 describe('MarkerPopupComponent', () => {
   let component: MarkerPopupComponent;
   let fixture: ComponentFixture<MarkerPopupComponent>;
+  let mockStateService: Partial<StateService>;
+  let mockUrlService: Partial<UrlService>;
 
   beforeEach(async () => {
+    mockStateService = {
+      getCodeTable: jest.fn().mockReturnValue([
+        { code: 'INITIAL', description: 'Initial' },
+        { code: 'PUBLISHED', description: 'Published' },
+        { code: 'FINALIZED', description: 'Finalized' },
+      ]),
+    };
+
+    mockUrlService = {
+      setQueryParam: jest.fn(),
+      setFragment: jest.fn(),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ MarkerPopupComponent ],
+      imports: [MarkerPopupComponent],
+      providers: [
+        { provide: StateService, useValue: mockStateService },
+        { provide: UrlService, useValue: mockUrlService },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(MarkerPopupComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should get workflow status from state service', () => {
+    fixture.detectChanges();
+    expect(mockStateService.getCodeTable).toHaveBeenCalledWith('workflowStateCode');
+  });
+
+  it('should index workflow status by code', () => {
+    fixture.detectChanges();
+    expect(component.workflowStatus['INITIAL']).toBeDefined();
+    expect(component.workflowStatus['INITIAL'].description).toBe('Initial');
+    expect(component.workflowStatus['PUBLISHED']).toBeDefined();
+    expect(component.workflowStatus['FINALIZED']).toBeDefined();
+  });
+
+  describe('showDetails', () => {
+    beforeEach(() => {
+      component.projectSummary = {
+        id: 42,
+        name: 'Test Project',
+      } as any;
+    });
+
+    it('should set query param with project id', () => {
+      component.showDetails();
+      expect(mockUrlService.setQueryParam).toHaveBeenCalledWith('id', '42');
+    });
+
+    it('should set fragment to details panel', () => {
+      component.showDetails();
+      expect(mockUrlService.setFragment).toHaveBeenCalledWith(Panel.details);
+    });
+  });
 });

--- a/public/src/app/applications/app-public-notices/notices-filter-panel/public-notices-filter-panel.component.spec.ts
+++ b/public/src/app/applications/app-public-notices/notices-filter-panel/public-notices-filter-panel.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { PublicNoticesFilterPanelComponent } from './public-notices-filter-panel.component';
+import { FormsModule } from '@angular/forms';
+import { PublicNoticesFilterPanelComponent, NoticeFilter } from './public-notices-filter-panel.component';
 
 describe('PublicNoticesFilterPanelComponent', () => {
   let component: PublicNoticesFilterPanelComponent;
@@ -7,16 +8,73 @@ describe('PublicNoticesFilterPanelComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ PublicNoticesFilterPanelComponent ],
+      imports: [PublicNoticesFilterPanelComponent, FormsModule],
     }).compileComponents();
     fixture = TestBed.createComponent(PublicNoticesFilterPanelComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should initialize filter on ngOnInit', () => {
+    component.ngOnInit();
+    expect(component.filter).toBeDefined();
+    expect(component.filter).toBeInstanceOf(NoticeFilter);
+  });
+
+  it('should initialize filter with null values', () => {
+    component.ngOnInit();
+    expect(component.filter.forestClientName.value).toBeNull();
+    expect(component.filter.districtName.value).toBeNull();
+    expect(component.filter.commentingOpenDate.value).toBeNull();
+  });
+
+  it('should have maxDate set to today', () => {
+    const today = new Date();
+    expect(component.maxDate.getFullYear()).toBe(today.getFullYear());
+    expect(component.maxDate.getMonth()).toBe(today.getMonth());
+    expect(component.maxDate.getDate()).toBe(today.getDate());
+  });
+
+  describe('onFilterChange', () => {
+    it('should emit filterPublicNoticesEvt', () => {
+      component.ngOnInit();
+      const emitSpy = jest.spyOn(component.filterPublicNoticesEvt, 'emit');
+      component.onFilterChange();
+      expect(emitSpy).toHaveBeenCalledWith(component.filter);
+    });
+  });
+
+  describe('districtList input', () => {
+    it('should accept districtList input', () => {
+      component.districtList = ['District A', 'District B'];
+      expect(component.districtList.length).toBe(2);
+      expect(component.districtList).toContain('District A');
+    });
+  });
+});
+
+describe('NoticeFilter', () => {
+  it('should have forestClientName field', () => {
+    const filter = new NoticeFilter();
+    expect(filter.forestClientName).toBeDefined();
+    expect(filter.forestClientName.queryParam).toBe('forestClientName');
+    expect(filter.forestClientName.value).toBeNull();
+  });
+
+  it('should have districtName field', () => {
+    const filter = new NoticeFilter();
+    expect(filter.districtName).toBeDefined();
+    expect(filter.districtName.queryParam).toBe('districtName');
+    expect(filter.districtName.value).toBeNull();
+  });
+
+  it('should have commentingOpenDate field', () => {
+    const filter = new NoticeFilter();
+    expect(filter.commentingOpenDate).toBeDefined();
+    expect(filter.commentingOpenDate.queryParam).toBe('commentingOpenDate');
+    expect(filter.commentingOpenDate.value).toBeNull();
+  });
 });

--- a/public/src/app/applications/app-public-notices/notices-filter-panel/public-notices-filter-panel.component.spec.ts
+++ b/public/src/app/applications/app-public-notices/notices-filter-panel/public-notices-filter-panel.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PublicNoticesFilterPanelComponent } from './public-notices-filter-panel.component';
+
+describe('PublicNoticesFilterPanelComponent', () => {
+  let component: PublicNoticesFilterPanelComponent;
+  let fixture: ComponentFixture<PublicNoticesFilterPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PublicNoticesFilterPanelComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(PublicNoticesFilterPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.spec.ts
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PublicNoticesPanelComponent } from './public-notices-panel.component';
+
+describe('PublicNoticesPanelComponent', () => {
+  let component: PublicNoticesPanelComponent;
+  let fixture: ComponentFixture<PublicNoticesPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PublicNoticesPanelComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(PublicNoticesPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.spec.ts
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.spec.ts
@@ -1,13 +1,54 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 import { PublicNoticesPanelComponent } from './public-notices-panel.component';
+import { PublicNoticeService } from '@api-client';
+import { UrlService } from '@public-core/services/url.service';
+import { Panel } from '../utils/panel.enum';
 
 describe('PublicNoticesPanelComponent', () => {
   let component: PublicNoticesPanelComponent;
   let fixture: ComponentFixture<PublicNoticesPanelComponent>;
+  let mockPublicNoticeService: Partial<PublicNoticeService>;
+  let mockUrlService: Partial<UrlService>;
+
+  const mockNotices = [
+    {
+      id: 1,
+      project: {
+        id: 10,
+        forestClient: { name: 'Client A' },
+        commentingOpenDate: '2025-01-01',
+        district: { name: 'District 1' },
+      },
+    },
+    {
+      id: 2,
+      project: {
+        id: 20,
+        forestClient: { name: 'Client B' },
+        commentingOpenDate: '2025-02-01',
+        district: { name: 'District 2' },
+      },
+    },
+  ];
 
   beforeEach(async () => {
+    mockPublicNoticeService = {
+      publicNoticeControllerFindListForPublicFrontEnd: jest.fn().mockReturnValue(of(mockNotices)),
+    };
+
+    mockUrlService = {
+      setQueryParam: jest.fn(),
+      setFragment: jest.fn(),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ PublicNoticesPanelComponent ],
+      imports: [PublicNoticesPanelComponent, RouterTestingModule],
+      providers: [
+        { provide: PublicNoticeService, useValue: mockPublicNoticeService },
+        { provide: UrlService, useValue: mockUrlService },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(PublicNoticesPanelComponent);
     component = fixture.componentInstance;
@@ -18,5 +59,86 @@ describe('PublicNoticesPanelComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should fetch public notices on init', () => {
+    expect(mockPublicNoticeService.publicNoticeControllerFindListForPublicFrontEnd).toHaveBeenCalled();
+  });
+
+  it('should populate pNotices from service response', () => {
+    expect(component.pNotices).toBeDefined();
+    expect(component.pNotices.length).toBe(2);
+  });
+
+  it('should populate initialPNotices from service response', () => {
+    expect(component.initialPNotices).toBeDefined();
+    expect(component.initialPNotices.length).toBe(2);
+  });
+
+  it('should build districtList from notices', () => {
+    expect(component.districtList).toBeDefined();
+    expect(component.districtList).toContain('District 1');
+    expect(component.districtList).toContain('District 2');
+    // Should be sorted
+    expect(component.districtList[0]).toBe('District 1');
+  });
+
+  it('should start with isLoading false', () => {
+    expect(component.isLoading).toBe(false);
+  });
+
+  describe('showDetails', () => {
+    it('should emit update with hidePanel true', () => {
+      const emitSpy = jest.spyOn(component.update, 'emit');
+      jest.useFakeTimers();
+      component.showDetails(42);
+      expect(emitSpy).toHaveBeenCalledWith({ search: false, resetMap: false, hidePanel: true });
+      jest.useRealTimers();
+    });
+
+    it('should set query param and fragment after delay', () => {
+      jest.useFakeTimers();
+      component.showDetails(42);
+      jest.advanceTimersByTime(500);
+      expect(mockUrlService.setQueryParam).toHaveBeenCalledWith('id', '42');
+      expect(mockUrlService.setFragment).toHaveBeenCalledWith(Panel.details);
+      jest.useRealTimers();
+    });
+  });
+
+  describe('handlePublicNoticesFilterUpdate', () => {
+    it('should filter notices by forest client name', () => {
+      component.handlePublicNoticesFilterUpdate({
+        forestClientName: { queryParam: 'fc', value: 'Client A' },
+        districtName: { queryParam: 'dn', value: null },
+        commentingOpenDate: { queryParam: 'cod', value: null },
+      } as any);
+      expect(component.pNotices.length).toBe(1);
+      expect(component.pNotices[0].project.forestClient.name).toBe('Client A');
+    });
+
+    it('should filter notices by district name', () => {
+      component.handlePublicNoticesFilterUpdate({
+        forestClientName: { queryParam: 'fc', value: null },
+        districtName: { queryParam: 'dn', value: 'District 2' },
+        commentingOpenDate: { queryParam: 'cod', value: null },
+      } as any);
+      expect(component.pNotices.length).toBe(1);
+      expect(component.pNotices[0].project.district.name).toBe('District 2');
+    });
+
+    it('should return all notices when no filter values set', () => {
+      component.handlePublicNoticesFilterUpdate({
+        forestClientName: { queryParam: 'fc', value: null },
+        districtName: { queryParam: 'dn', value: null },
+        commentingOpenDate: { queryParam: 'cod', value: null },
+      } as any);
+      expect(component.pNotices.length).toBe(2);
+    });
+  });
+
+  describe('isFomAvailable', () => {
+    it('should return true for past date', () => {
+      const result = component.isFomAvailable('2020-01-01');
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/public/src/app/applications/app-public-notices/public-notices-panel.component.spec.ts
+++ b/public/src/app/applications/app-public-notices/public-notices-panel.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { PublicNoticesPanelComponent } from './public-notices-panel.component';
 import { PublicNoticeService } from '@api-client';
@@ -44,8 +44,9 @@ describe('PublicNoticesPanelComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [PublicNoticesPanelComponent, RouterTestingModule],
+      imports: [PublicNoticesPanelComponent],
       providers: [
+        provideRouter([]),
         { provide: PublicNoticeService, useValue: mockPublicNoticeService },
         { provide: UrlService, useValue: mockUrlService },
       ],

--- a/public/src/app/applications/details-panel/details-map/details-map.component.spec.ts
+++ b/public/src/app/applications/details-panel/details-map/details-map.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DetailsMapComponent } from './details-map.component';
+
+describe('DetailsMapComponent', () => {
+  let component: DetailsMapComponent;
+  let fixture: ComponentFixture<DetailsMapComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DetailsMapComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(DetailsMapComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/details-panel/details-map/details-map.component.spec.ts
+++ b/public/src/app/applications/details-panel/details-map/details-map.component.spec.ts
@@ -1,22 +1,66 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetailsMapComponent } from './details-map.component';
+import { MapLayersService } from '@public-core/services/mapLayers.service';
+import { FeatureSelectService } from '@utility/services/featureSelect.service';
+import { Subject } from 'rxjs';
 
 describe('DetailsMapComponent', () => {
   let component: DetailsMapComponent;
   let fixture: ComponentFixture<DetailsMapComponent>;
+  let mockMapLayersService: Partial<MapLayersService>;
+  let mockFeatureSelectService: Partial<FeatureSelectService>;
 
   beforeEach(async () => {
+    mockMapLayersService = {
+      $mapLayersChange: { subscribe: jest.fn() } as any,
+      notifyLayersChange: jest.fn(),
+      mapLayersUpdate: jest.fn(),
+      applyCurrentMapLayers: jest.fn(),
+    };
+
+    mockFeatureSelectService = {
+      $currentSelected: new Subject<any>(),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ DetailsMapComponent ],
+      imports: [DetailsMapComponent],
+      providers: [
+        { provide: MapLayersService, useValue: mockMapLayersService },
+        { provide: FeatureSelectService, useValue: mockFeatureSelectService },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(DetailsMapComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  describe('resetMap', () => {
+    it('should not throw when map is null', () => {
+      component.map = null;
+      expect(() => component.resetMap()).not.toThrow();
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should unsubscribe', () => {
+      const nextSpy = jest.spyOn(component['ngUnsubscribe'], 'next');
+      const completeSpy = jest.spyOn(component['ngUnsubscribe'], 'complete');
+      component.ngOnDestroy();
+      expect(nextSpy).toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('input properties', () => {
+    it('should accept projectSpatialDetail input', () => {
+      const details = [
+        { featureId: 1, featureType: { code: 'cut_block' } },
+      ] as any;
+      component.projectSpatialDetail = details;
+      expect(component.projectSpatialDetail).toBe(details);
+    });
+  });
 });

--- a/public/src/app/applications/details-panel/details-panel.component.spec.ts
+++ b/public/src/app/applications/details-panel/details-panel.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DetailsPanelComponent } from './details-panel.component';
+
+describe('DetailsPanelComponent', () => {
+  let component: DetailsPanelComponent;
+  let fixture: ComponentFixture<DetailsPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DetailsPanelComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(DetailsPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/details-panel/details-panel.component.spec.ts
+++ b/public/src/app/applications/details-panel/details-panel.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { DetailsPanelComponent } from './details-panel.component';
 import { ProjectService, SpatialFeatureService, AttachmentService } from '@api-client';
 import { UrlService } from '@public-core/services/url.service';
@@ -65,8 +65,9 @@ describe('DetailsPanelComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [DetailsPanelComponent, RouterTestingModule],
+      imports: [DetailsPanelComponent],
       providers: [
+        provideRouter([]),
         { provide: ProjectService, useValue: mockProjectService },
         { provide: SpatialFeatureService, useValue: mockSpatialFeatureService },
         { provide: AttachmentService, useValue: mockAttachmentService },

--- a/public/src/app/applications/details-panel/details-panel.component.spec.ts
+++ b/public/src/app/applications/details-panel/details-panel.component.spec.ts
@@ -1,13 +1,80 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { DetailsPanelComponent } from './details-panel.component';
+import { ProjectService, SpatialFeatureService, AttachmentService } from '@api-client';
+import { UrlService } from '@public-core/services/url.service';
+import { FeatureSelectService } from '@utility/services/featureSelect.service';
+import { ConfigService } from '@utility/services/config.service';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { of, Subject } from 'rxjs';
 
 describe('DetailsPanelComponent', () => {
   let component: DetailsPanelComponent;
   let fixture: ComponentFixture<DetailsPanelComponent>;
+  let mockProjectService: Partial<ProjectService>;
+  let mockSpatialFeatureService: Partial<SpatialFeatureService>;
+  let mockAttachmentService: Partial<AttachmentService>;
+  let mockUrlService: Partial<UrlService>;
+  let mockFeatureSelectService: Partial<FeatureSelectService>;
+  let mockConfigService: Partial<ConfigService>;
+  let mockModalService: Partial<NgbModal>;
+  let navEndSubject: Subject<any>;
 
   beforeEach(async () => {
+    navEndSubject = new Subject<any>();
+
+    mockProjectService = {
+      workflowStateCodeControllerFindAll: jest.fn().mockReturnValue(of([
+        { code: 'INITIAL', description: 'Initial' },
+        { code: 'PUBLISHED', description: 'Published' },
+      ])),
+      projectControllerFindOne: jest.fn().mockReturnValue(of({
+        id: 1,
+        name: 'Test Project',
+      })),
+    };
+
+    mockSpatialFeatureService = {
+      spatialFeatureControllerGetForProject: jest.fn().mockReturnValue(of([])),
+    };
+
+    mockAttachmentService = {
+      attachmentControllerFind: jest.fn().mockReturnValue(of([])),
+    };
+
+    mockUrlService = {
+      onNavEnd$: navEndSubject.asObservable() as any,
+      getQueryParam: jest.fn().mockReturnValue(null),
+      setQueryParam: jest.fn(),
+    };
+
+    mockFeatureSelectService = {
+      $currentSelected: new Subject<any>(),
+    };
+
+    mockConfigService = {
+      getEnvironmentDisplay: jest.fn().mockReturnValue('Dev'),
+    };
+
+    mockModalService = {
+      open: jest.fn().mockReturnValue({
+        result: Promise.resolve(),
+        dismiss: jest.fn(),
+        componentInstance: {},
+      }),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ DetailsPanelComponent ],
+      imports: [DetailsPanelComponent, RouterTestingModule],
+      providers: [
+        { provide: ProjectService, useValue: mockProjectService },
+        { provide: SpatialFeatureService, useValue: mockSpatialFeatureService },
+        { provide: AttachmentService, useValue: mockAttachmentService },
+        { provide: UrlService, useValue: mockUrlService },
+        { provide: FeatureSelectService, useValue: mockFeatureSelectService },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: NgbModal, useValue: mockModalService },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(DetailsPanelComponent);
     component = fixture.componentInstance;
@@ -18,5 +85,69 @@ describe('DetailsPanelComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should load workflow state codes on init', () => {
+    expect(mockProjectService.workflowStateCodeControllerFindAll).toHaveBeenCalled();
+  });
+
+  it('should populate workflowStatus', () => {
+    expect(component.workflowStatus).toBeDefined();
+    expect(component.workflowStatus['INITIAL']).toBeDefined();
+    expect(component.workflowStatus['PUBLISHED']).toBeDefined();
+  });
+
+  it('should have projectPlanCodeEnum', () => {
+    expect(component.projectPlanCodeEnum).toBeDefined();
+  });
+
+  it('should have faArrowUpRightFromSquare icon', () => {
+    expect(component.faArrowUpRightFromSquare).toBeDefined();
+  });
+
+  describe('clearAllFilters', () => {
+    it('should reset projectIdFilter', () => {
+      component.projectIdFilter.filter.value = '42';
+      component.clearAllFilters();
+      expect(component.projectIdFilter.filter.value).toBeNull();
+    });
+  });
+
+  describe('loadQueryParameters', () => {
+    it('should load project id from url', () => {
+      (mockUrlService.getQueryParam as jest.Mock).mockReturnValue('99');
+      component.loadQueryParameters();
+      expect(component.projectIdFilter.filter.value).toBe('99');
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should unsubscribe', () => {
+      const nextSpy = jest.spyOn(component['ngUnsubscribe'], 'next');
+      const completeSpy = jest.spyOn(component['ngUnsubscribe'], 'complete');
+      component.ngOnDestroy();
+      expect(nextSpy).toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+
+    it('should dismiss comment modal if exists', () => {
+      const mockDismiss = jest.fn();
+      component.addCommentModal = {
+        componentInstance: { dismiss: mockDismiss },
+      } as any;
+      component.ngOnDestroy();
+      expect(mockDismiss).toHaveBeenCalledWith('destroying');
+    });
+
+    it('should not throw if comment modal is null', () => {
+      component.addCommentModal = null;
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
+  });
+
+  describe('getProjectDetails', () => {
+    it('should set project to null when no project id in query params', () => {
+      (mockUrlService.getQueryParam as jest.Mock).mockReturnValue(null);
+      component.getProjectDetails();
+      expect(component.project).toBeNull();
+    });
+  });
 });

--- a/public/src/app/applications/details-panel/shape-info/shape-info.component.spec.ts
+++ b/public/src/app/applications/details-panel/shape-info/shape-info.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ShapeInfoComponent } from './shape-info.component';
+
+describe('ShapeInfoComponent', () => {
+  let component: ShapeInfoComponent;
+  let fixture: ComponentFixture<ShapeInfoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ShapeInfoComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ShapeInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/details-panel/shape-info/shape-info.component.spec.ts
+++ b/public/src/app/applications/details-panel/shape-info/shape-info.component.spec.ts
@@ -1,22 +1,74 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ShapeInfoComponent } from './shape-info.component';
+import { FeatureSelectService } from '@utility/services/featureSelect.service';
 
 describe('ShapeInfoComponent', () => {
   let component: ShapeInfoComponent;
   let fixture: ComponentFixture<ShapeInfoComponent>;
+  let mockFeatureSelectService: Partial<FeatureSelectService>;
 
   beforeEach(async () => {
+    mockFeatureSelectService = {
+      changeSelectedFeature: jest.fn(),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ ShapeInfoComponent ],
+      imports: [ShapeInfoComponent],
+      providers: [
+        { provide: FeatureSelectService, useValue: mockFeatureSelectService },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(ShapeInfoComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should have correct displayed columns', () => {
+    expect(component.displayedColumns).toEqual([
+      'shape_id', 'type', 'name', 'submission_type', 'area_length', 'development_date'
+    ]);
+  });
+
+  it('should start with no selected row', () => {
+    expect(component.selectedRowIndex).toBeNull();
+  });
+
+  it('should have slideColor set to primary', () => {
+    expect(component.slideColor).toBe('primary');
+  });
+
+  describe('onRowSelected', () => {
+    it('should set selectedRowIndex from featureId and featureType code', () => {
+      const rowData = { featureId: 5, featureType: { code: 'cut_block' } };
+      component.onRowSelected(rowData as any);
+      expect(component.selectedRowIndex).toBe('5-cut_block');
+    });
+
+    it('should call featureSelectService.changeSelectedFeature', () => {
+      const rowData = { featureId: 5, featureType: { code: 'cut_block' } };
+      component.onRowSelected(rowData as any);
+      expect(mockFeatureSelectService.changeSelectedFeature).toHaveBeenCalledWith('5-cut_block');
+    });
+
+    it('should update selectedRowIndex on subsequent selections', () => {
+      component.onRowSelected({ featureId: 1, featureType: { code: 'road_section' } } as any);
+      expect(component.selectedRowIndex).toBe('1-road_section');
+      component.onRowSelected({ featureId: 2, featureType: { code: 'cut_block' } } as any);
+      expect(component.selectedRowIndex).toBe('2-cut_block');
+    });
+  });
+
+  describe('spatialDetail input', () => {
+    it('should accept spatialDetail input', () => {
+      const mockSpatialDetail = [
+        { featureId: 1, featureType: { code: 'cut_block' }, name: 'Block A' },
+        { featureId: 2, featureType: { code: 'road_section' }, name: 'Road 1' },
+      ];
+      component.projectSpatialDetail = mockSpatialDetail as any;
+      expect(component.projectSpatialDetail.length).toBe(2);
+    });
+  });
 });

--- a/public/src/app/applications/find-panel/find-panel.component.spec.ts
+++ b/public/src/app/applications/find-panel/find-panel.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { FindPanelComponent } from './find-panel.component';
@@ -49,8 +49,9 @@ describe('FindPanelComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [FindPanelComponent, RouterTestingModule, FormsModule],
+      imports: [FindPanelComponent, FormsModule],
       providers: [
+        provideRouter([]),
         { provide: UrlService, useValue: mockUrlService },
         { provide: FOMFiltersService, useValue: mockFomFiltersSvc },
       ],

--- a/public/src/app/applications/find-panel/find-panel.component.spec.ts
+++ b/public/src/app/applications/find-panel/find-panel.component.spec.ts
@@ -5,7 +5,7 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import { FindPanelComponent } from './find-panel.component';
 import { FOMFiltersService, FOM_FILTER_NAME, COMMENT_STATUS_FILTER_PARAMS } from '@public-core/services/fomFilters.service';
 import { UrlService } from '@public-core/services/url.service';
-import { Filter, MultiFilter, FilterUtils } from '../utils/filter';
+import { Filter, MultiFilter } from '../utils/filter';
 
 describe('FindPanelComponent', () => {
   let component: FindPanelComponent;

--- a/public/src/app/applications/find-panel/find-panel.component.spec.ts
+++ b/public/src/app/applications/find-panel/find-panel.component.spec.ts
@@ -1,13 +1,59 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule } from '@angular/forms';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { FindPanelComponent } from './find-panel.component';
+import { FOMFiltersService, FOM_FILTER_NAME, COMMENT_STATUS_FILTER_PARAMS } from '@public-core/services/fomFilters.service';
+import { UrlService } from '@public-core/services/url.service';
+import { Filter, MultiFilter, FilterUtils } from '../utils/filter';
 
 describe('FindPanelComponent', () => {
   let component: FindPanelComponent;
   let fixture: ComponentFixture<FindPanelComponent>;
+  let mockUrlService: Partial<UrlService>;
+  let mockFomFiltersSvc: Partial<FOMFiltersService>;
+  let filtersSubject: BehaviorSubject<Map<string, any>>;
+  let navEndSubject: Subject<any>;
+
+  function createDefaultFilters(): Map<string, any> {
+    const filters = new Map();
+    const commentStatusFilters = new MultiFilter<boolean>({
+      queryParamsKey: FOM_FILTER_NAME.COMMENT_STATUS,
+      filters: [
+        { queryParam: COMMENT_STATUS_FILTER_PARAMS.COMMENT_OPEN, displayString: 'Commenting Open', value: true },
+        { queryParam: COMMENT_STATUS_FILTER_PARAMS.COMMENT_CLOSED, displayString: 'Commenting Closed', value: false },
+      ],
+    });
+    filters.set(FOM_FILTER_NAME.FOM_NUMBER, new Filter<number>({ filter: { queryParam: FOM_FILTER_NAME.FOM_NUMBER, value: null } }));
+    filters.set(FOM_FILTER_NAME.FOREST_CLIENT_NAME, new Filter<string>({ filter: { queryParam: FOM_FILTER_NAME.FOREST_CLIENT_NAME, value: null } }));
+    filters.set(FOM_FILTER_NAME.COMMENT_STATUS, commentStatusFilters);
+    filters.set(FOM_FILTER_NAME.POSTED_ON_AFTER, new Filter<Date>({ filter: { queryParam: FOM_FILTER_NAME.POSTED_ON_AFTER, value: null } }));
+    return filters;
+  }
 
   beforeEach(async () => {
+    navEndSubject = new Subject<any>();
+    filtersSubject = new BehaviorSubject<Map<string, any>>(createDefaultFilters());
+
+    mockUrlService = {
+      onNavEnd$: navEndSubject.asObservable() as any,
+      getQueryParam: jest.fn().mockReturnValue(null),
+      setQueryParam: jest.fn(),
+      setFragment: jest.fn(),
+    };
+
+    mockFomFiltersSvc = {
+      filters$: filtersSubject.asObservable(),
+      clearFilters: jest.fn(),
+      updateFiltersSelection: jest.fn(),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ FindPanelComponent ],
+      imports: [FindPanelComponent, RouterTestingModule, FormsModule],
+      providers: [
+        { provide: UrlService, useValue: mockUrlService },
+        { provide: FOMFiltersService, useValue: mockFomFiltersSvc },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(FindPanelComponent);
     component = fixture.componentInstance;
@@ -18,5 +64,131 @@ describe('FindPanelComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should have maxInputLength of 9', () => {
+    expect(component.maxInputLength).toBe(9);
+  });
+
+  it('should have minDate set to 2018-03-23', () => {
+    expect(component.minDate).toBeDefined();
+    expect(component.minDate.getFullYear()).toBe(2018);
+    expect(component.minDate.getMonth()).toBe(2); // March (0-indexed)
+    expect(component.minDate.getDate()).toBe(23);
+  });
+
+  describe('verifyFomNumberInput', () => {
+    it('should parse valid integer input', () => {
+      const event = { target: { value: '123' } };
+      component.verifyFomNumberInput(event);
+      expect(component.fomNumberFilter.filter.value).toBe(123);
+    });
+
+    it('should strip leading zeros', () => {
+      const event = { target: { value: '007' } };
+      component.verifyFomNumberInput(event);
+      expect(component.fomNumberFilter.filter.value).toBe(7);
+    });
+
+    it('should set null for NaN input', () => {
+      const event = { target: { value: 'abc' } };
+      component.verifyFomNumberInput(event);
+      expect(component.fomNumberFilter.filter.value).toBeNull();
+    });
+
+    it('should set null for zero input', () => {
+      const event = { target: { value: '0' } };
+      component.verifyFomNumberInput(event);
+      expect(component.fomNumberFilter.filter.value).toBeNull();
+    });
+  });
+
+  describe('verifyStatus', () => {
+    it('should set commentOpen to true if both are false', () => {
+      component.commentStatusFilters.filters.forEach(f => f.value = false);
+      component.verifyStatus();
+      const commentOpen = component.commentStatusFilters.filters.find(
+        f => f.queryParam === COMMENT_STATUS_FILTER_PARAMS.COMMENT_OPEN
+      );
+      expect(commentOpen.value).toBe(true);
+    });
+
+    it('should not change values if at least one is true', () => {
+      component.commentStatusFilters.filters[0].value = true;
+      component.commentStatusFilters.filters[1].value = false;
+      component.verifyStatus();
+      expect(component.commentStatusFilters.filters[0].value).toBe(true);
+      expect(component.commentStatusFilters.filters[1].value).toBe(false);
+    });
+  });
+
+  describe('toggleFilter', () => {
+    it('should toggle filter value from true to false', () => {
+      const filter = { queryParam: 'test', displayString: 'Test', value: true };
+      component.toggleFilter(filter);
+      expect(filter.value).toBe(false);
+    });
+
+    it('should toggle filter value from false to true', () => {
+      const filter = { queryParam: 'test', displayString: 'Test', value: false };
+      component.toggleFilter(filter);
+      expect(filter.value).toBe(true);
+    });
+  });
+
+  describe('clear', () => {
+    it('should call clearFilters and emit update', () => {
+      const emitSpy = jest.spyOn(component.update, 'emit');
+      component.clear();
+      expect(mockFomFiltersSvc.clearFilters).toHaveBeenCalled();
+      expect(emitSpy).toHaveBeenCalledWith({ search: true, resetMap: true, hidePanel: true });
+    });
+  });
+
+  describe('clearAllFilters', () => {
+    it('should call fomFiltersSvc.clearFilters', () => {
+      component.clearAllFilters();
+      expect(mockFomFiltersSvc.clearFilters).toHaveBeenCalled();
+    });
+  });
+
+  describe('checkAndSetFiltersHash', () => {
+    it('should return true on first call (no previous hash)', () => {
+      expect(component.checkAndSetFiltersHash()).toBe(true);
+    });
+
+    it('should return false if filters have not changed', () => {
+      component.checkAndSetFiltersHash();
+      expect(component.checkAndSetFiltersHash()).toBe(false);
+    });
+
+    it('should return true if filters have changed', () => {
+      component.checkAndSetFiltersHash();
+      component.fomNumberFilter.filter.value = 42;
+      expect(component.checkAndSetFiltersHash()).toBe(true);
+    });
+  });
+
+  describe('emitUpdate', () => {
+    it('should emit when filters changed', () => {
+      const emitSpy = jest.spyOn(component.update, 'emit');
+      component.emitUpdate({ search: true });
+      expect(emitSpy).toHaveBeenCalledWith({ search: true });
+    });
+
+    it('should not emit when filters unchanged', () => {
+      const emitSpy = jest.spyOn(component.update, 'emit');
+      component.checkAndSetFiltersHash(); // set initial hash
+      component.emitUpdate({ search: true });
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should unsubscribe', () => {
+      const nextSpy = jest.spyOn(component['ngUnsubscribe'], 'next');
+      const completeSpy = jest.spyOn(component['ngUnsubscribe'], 'complete');
+      component.ngOnDestroy();
+      expect(nextSpy).toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/public/src/app/applications/find-panel/find-panel.component.spec.ts
+++ b/public/src/app/applications/find-panel/find-panel.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FindPanelComponent } from './find-panel.component';
+
+describe('FindPanelComponent', () => {
+  let component: FindPanelComponent;
+  let fixture: ComponentFixture<FindPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FindPanelComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(FindPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/projects.component.spec.ts
+++ b/public/src/app/applications/projects.component.spec.ts
@@ -1,22 +1,184 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { ProjectsComponent } from './projects.component';
+import { ProjectService } from '@api-client';
+import { FOMFiltersService, FOM_FILTER_NAME } from '@public-core/services/fomFilters.service';
+import { UrlService } from '@public-core/services/url.service';
+import { Filter, MultiFilter } from './utils/filter';
+import { Panel } from './utils/panel.enum';
 
 describe('ProjectsComponent', () => {
   let component: ProjectsComponent;
-  let fixture: ComponentFixture<ProjectsComponent>;
+  let mockModalService: Partial<NgbModal>;
+  let mockProjectService: Partial<ProjectService>;
+  let mockFomFiltersSvc: Partial<FOMFiltersService>;
+  let mockUrlService: Partial<UrlService>;
+  let filtersSubject: BehaviorSubject<Map<string, any>>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ ProjectsComponent ],
-    }).compileComponents();
-    fixture = TestBed.createComponent(ProjectsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(() => {
+    filtersSubject = new BehaviorSubject<Map<string, any>>(new Map());
+
+    mockModalService = {
+      open: jest.fn().mockReturnValue({
+        result: Promise.resolve(),
+        dismiss: jest.fn(),
+        close: jest.fn(),
+      }),
+    };
+
+    mockProjectService = {
+      projectControllerFindPublicSummary: jest.fn().mockReturnValue(of([])),
+    };
+
+    mockUrlService = {
+      onNavEnd$: new Subject<any>().asObservable() as any,
+      setFragment: jest.fn(),
+      setQueryParam: jest.fn(),
+    };
+
+    const defaultFilters = new Map();
+    const commentStatusFilters = new MultiFilter<boolean>({
+      queryParamsKey: 'cmtStatus',
+      filters: [
+        { queryParam: 'COMMENT_OPEN', displayString: 'Commenting Open', value: true },
+        { queryParam: 'COMMENT_CLOSED', displayString: 'Commenting Closed', value: false },
+      ],
+    });
+    defaultFilters.set(FOM_FILTER_NAME.FOM_NUMBER, new Filter<number>({ filter: { queryParam: 'fomNumber', value: null } }));
+    defaultFilters.set(FOM_FILTER_NAME.FOREST_CLIENT_NAME, new Filter<string>({ filter: { queryParam: 'fcName', value: null } }));
+    defaultFilters.set(FOM_FILTER_NAME.COMMENT_STATUS, commentStatusFilters);
+    defaultFilters.set(FOM_FILTER_NAME.POSTED_ON_AFTER, new Filter<Date>({ filter: { queryParam: 'pdOnAfter', value: null } }));
+    filtersSubject.next(defaultFilters);
+
+    mockFomFiltersSvc = {
+      filters$: filtersSubject.asObservable(),
+      clearFilters: jest.fn(),
+      updateFilterSelection: jest.fn(),
+    };
+
+    // Instantiate directly to avoid child component DI issues
+    component = new ProjectsComponent(
+      mockModalService as any,
+      null as any, // Router
+      mockProjectService as any,
+      mockUrlService as any,
+      mockFomFiltersSvc as any,
+    );
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should start with no active panel', () => {
+    expect(component.activePanel).toBeUndefined();
+  });
+
+  it('should start with loading false', () => {
+    expect(component.loading).toBe(false);
+  });
+
+  describe('closeSidePanel', () => {
+    it('should set activePanel to null', () => {
+      component.activePanel = Panel.find;
+      component.closeSidePanel();
+      expect(component.activePanel).toBeNull();
+    });
+
+    it('should clear url fragment', () => {
+      component.activePanel = Panel.find;
+      component.closeSidePanel();
+      expect(mockUrlService.setFragment).toHaveBeenCalledWith(null);
+    });
+
+    it('should do nothing if no panel is active', () => {
+      component.activePanel = null;
+      component.closeSidePanel();
+      expect(mockUrlService.setFragment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('togglePanel', () => {
+    it('should activate panel when different panel is active', () => {
+      (component as any).urlTree = { fragment: null };
+      component.togglePanel(Panel.find);
+      expect(component.activePanel).toBe(Panel.find);
+      expect(mockUrlService.setFragment).toHaveBeenCalledWith(Panel.find);
+    });
+
+    it('should deactivate panel when same panel is toggled', () => {
+      (component as any).urlTree = { fragment: 'find' };
+      component.activePanel = Panel.find;
+      component.togglePanel(Panel.find);
+      expect(component.activePanel).toBeNull();
+      expect(mockUrlService.setFragment).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('clearFilters', () => {
+    it('should call fomFiltersSvc.clearFilters', () => {
+      component.clearFilters();
+      expect(mockFomFiltersSvc.clearFilters).toHaveBeenCalled();
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should unsubscribe', () => {
+      const nextSpy = jest.spyOn(component['ngUnsubscribe'], 'next');
+      const completeSpy = jest.spyOn(component['ngUnsubscribe'], 'complete');
+      component.ngOnDestroy();
+      expect(nextSpy).toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+
+    it('should dismiss splash modal if it exists', () => {
+      const mockModal = { dismiss: jest.fn() };
+      (component as any).splashModal = mockModal;
+      component.ngOnDestroy();
+      expect(mockModal.dismiss).toHaveBeenCalled();
+    });
+
+    it('should not throw if splash modal is null', () => {
+      (component as any).splashModal = null;
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
+  });
+
+  describe('displaySplashModal', () => {
+    it('should open the splash modal', () => {
+      component.displaySplashModal();
+      expect(mockModalService.open).toHaveBeenCalled();
+    });
+  });
+
+  describe('closeSplashModal', () => {
+    it('should close the splash modal if it exists', () => {
+      const mockModal = { close: jest.fn() };
+      (component as any).splashModal = mockModal;
+      component.closeSplashModal();
+      expect(mockModal.close).toHaveBeenCalled();
+    });
+
+    it('should not throw if splash modal is null', () => {
+      (component as any).splashModal = null;
+      expect(() => component.closeSplashModal()).not.toThrow();
+    });
+  });
+
+  describe('handleFindUpdate', () => {
+    it('should handle hidePanel event', () => {
+      component.activePanel = Panel.find;
+      component.handleFindUpdate({ hidePanel: true });
+      expect(component.activePanel).toBeNull();
+    });
+  });
+
+  describe('handlePublicNoticesUpdate', () => {
+    it('should handle hidePanel event', () => {
+      component.activePanel = Panel.publicNotices;
+      component.handlePublicNoticesUpdate({ hidePanel: true });
+      expect(component.activePanel).toBeNull();
+    });
+  });
 });

--- a/public/src/app/applications/projects.component.spec.ts
+++ b/public/src/app/applications/projects.component.spec.ts
@@ -1,4 +1,3 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { ProjectsComponent } from './projects.component';

--- a/public/src/app/applications/projects.component.spec.ts
+++ b/public/src/app/applications/projects.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProjectsComponent } from './projects.component';
+
+describe('ProjectsComponent', () => {
+  let component: ProjectsComponent;
+  let fixture: ComponentFixture<ProjectsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ProjectsComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ProjectsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/projects.component.spec.ts
+++ b/public/src/app/applications/projects.component.spec.ts
@@ -7,7 +7,7 @@ describe('ProjectsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ProjectsComponent],
+      declarations: [ ProjectsComponent ],
     }).compileComponents();
     fixture = TestBed.createComponent(ProjectsComponent);
     component = fixture.componentInstance;

--- a/public/src/app/applications/splash-modal/splash-modal.component.spec.ts
+++ b/public/src/app/applications/splash-modal/splash-modal.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router, provideRouter } from '@angular/router';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { SplashModalComponent, SplashModalResult } from './splash-modal.component';
 import { UrlService } from '@public-core/services/url.service';
@@ -22,8 +21,9 @@ describe('SplashModalComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [SplashModalComponent, RouterTestingModule],
+      imports: [SplashModalComponent],
       providers: [
+        provideRouter([]),
         { provide: NgbActiveModal, useValue: mockActiveModal },
         { provide: UrlService, useValue: mockUrlService },
         {

--- a/public/src/app/applications/splash-modal/splash-modal.component.spec.ts
+++ b/public/src/app/applications/splash-modal/splash-modal.component.spec.ts
@@ -1,14 +1,43 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SplashModalComponent } from './splash-modal.component';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { SplashModalComponent, SplashModalResult } from './splash-modal.component';
+import { UrlService } from '@public-core/services/url.service';
 
 describe('SplashModalComponent', () => {
   let component: SplashModalComponent;
   let fixture: ComponentFixture<SplashModalComponent>;
+  let mockActiveModal: Partial<NgbActiveModal>;
+  let mockUrlService: Partial<UrlService>;
+  let router: Router;
 
   beforeEach(async () => {
+    mockActiveModal = {
+      close: jest.fn(),
+    };
+
+    mockUrlService = {
+      setFragment: jest.fn(),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ SplashModalComponent ],
+      imports: [SplashModalComponent, RouterTestingModule],
+      providers: [
+        { provide: NgbActiveModal, useValue: mockActiveModal },
+        { provide: UrlService, useValue: mockUrlService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {},
+          },
+        },
+      ],
     }).compileComponents();
+
+    router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate');
+
     fixture = TestBed.createComponent(SplashModalComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -18,5 +47,34 @@ describe('SplashModalComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for logic, template, and events as needed
+  it('should have faArrowUpRightFromSquare icon', () => {
+    expect(component.faArrowUpRightFromSquare).toBeDefined();
+  });
+
+  describe('dismiss', () => {
+    it('should close modal with Dismissed result', () => {
+      component.dismiss();
+      expect(mockActiveModal.close).toHaveBeenCalledWith(SplashModalResult.Dismissed);
+    });
+
+    it('should clear url fragment', () => {
+      component.dismiss();
+      expect(mockUrlService.setFragment).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('explore', () => {
+    it('should close modal with Exploring result', () => {
+      component.explore();
+      expect(mockActiveModal.close).toHaveBeenCalledWith(SplashModalResult.Exploring);
+    });
+
+    it('should navigate to find fragment', () => {
+      component.explore();
+      expect(router.navigate).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({ fragment: 'find', replaceUrl: true })
+      );
+    });
+  });
 });

--- a/public/src/app/applications/splash-modal/splash-modal.component.spec.ts
+++ b/public/src/app/applications/splash-modal/splash-modal.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SplashModalComponent } from './splash-modal.component';
+
+describe('SplashModalComponent', () => {
+  let component: SplashModalComponent;
+  let fixture: ComponentFixture<SplashModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SplashModalComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(SplashModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for logic, template, and events as needed
+});

--- a/public/src/app/applications/utils/date-input/date-input.component.spec.ts
+++ b/public/src/app/applications/utils/date-input/date-input.component.spec.ts
@@ -1,32 +1,101 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DateInputComponent } from './date-input.component';
-import { NgbDatepicker, NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { FormsModule } from '@angular/forms';
 
 describe('DateInputComponent', () => {
   let component: DateInputComponent;
   let fixture: ComponentFixture<DateInputComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DateInputComponent],
-      imports: [NgbModule, FormsModule],
-      providers: [NgbDatepicker]
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DateInputComponent],
+    })
+      .overrideComponent(DateInputComponent, {
+        set: { template: '<div></div>', styles: [] },
+      })
+      .compileComponents();
     fixture = TestBed.createComponent(DateInputComponent);
     component = fixture.componentInstance;
-
-    component.date = new Date(2018, 12, 12);
-    component.minDate = new Date(2018, 1, 1);
-    component.maxDate = new Date(2018, 12, 30);
-
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize with null ngbDate', () => {
+    expect(component.ngbDate).toBeNull();
+  });
+
+  it('should convert Date to NgbDateStruct on ngOnChanges', () => {
+    const testDate = new Date(2023, 5, 15);
+    component.date = testDate;
+    component.ngOnChanges({ date: { currentValue: testDate, previousValue: null, firstChange: true, isFirstChange: () => true } });
+    expect(component.ngbDate).toEqual({ year: 2023, month: 6, day: 15 });
+  });
+
+  it('should convert null Date to null NgbDateStruct', () => {
+    component.date = null;
+    component.ngOnChanges({ date: { currentValue: null, previousValue: new Date(), firstChange: false, isFirstChange: () => false } });
+    expect(component.ngbDate).toBeNull();
+  });
+
+  it('should convert minDate on ngOnChanges', () => {
+    const minDate = new Date(2020, 0, 1);
+    component.minDate = minDate;
+    component.ngOnChanges({ minDate: { currentValue: minDate, previousValue: null, firstChange: true, isFirstChange: () => true } });
+    expect(component.minNgbDate).toEqual({ year: 2020, month: 1, day: 1 });
+  });
+
+  it('should convert maxDate on ngOnChanges', () => {
+    const maxDate = new Date(2025, 11, 31);
+    component.maxDate = maxDate;
+    component.ngOnChanges({ maxDate: { currentValue: maxDate, previousValue: null, firstChange: true, isFirstChange: () => true } });
+    expect(component.maxNgbDate).toEqual({ year: 2025, month: 12, day: 31 });
+  });
+
+  it('should validate valid date', () => {
+    expect(component.isValidDate({ year: 2023, month: 6, day: 15 })).toBe(true);
+  });
+
+  it('should invalidate null date', () => {
+    expect(component.isValidDate(null)).toBeFalsy();
+  });
+
+  it('should invalidate date with NaN values', () => {
+    expect(component.isValidDate({ year: NaN, month: 1, day: 1 })).toBe(false);
+    expect(component.isValidDate({ year: 2023, month: NaN, day: 1 })).toBe(false);
+    expect(component.isValidDate({ year: 2023, month: 1, day: NaN })).toBe(false);
+  });
+
+  it('should emit dateChange on onDateChg', () => {
+    const emitSpy = jest.spyOn(component.dateChange, 'emit');
+    component.ngbDate = { year: 2023, month: 6, day: 15 };
+    component.onDateChg(component.ngbDate);
+    expect(emitSpy).toHaveBeenCalled();
+    const emitted = emitSpy.mock.calls[0][0];
+    expect(emitted.getFullYear()).toBe(2023);
+    expect(emitted.getMonth()).toBe(5);
+    expect(emitted.getDate()).toBe(15);
+  });
+
+  it('should emit null on onDateChg with null date', () => {
+    const emitSpy = jest.spyOn(component.dateChange, 'emit');
+    component.onDateChg(null);
+    expect(emitSpy).toHaveBeenCalledWith(null);
+  });
+
+  it('should clear date and emit null', () => {
+    const emitSpy = jest.spyOn(component.dateChange, 'emit');
+    component.ngbDate = { year: 2023, month: 6, day: 15 };
+    component.clearDate();
+    expect(component.ngbDate).toBeNull();
+    expect(emitSpy).toHaveBeenCalledWith(null);
+  });
+
+  it('should have default isValidate as false', () => {
+    expect(component.isValidate).toBe(false);
+  });
+
+  it('should have dateChange EventEmitter', () => {
+    expect(component.dateChange).toBeDefined();
   });
 });

--- a/public/src/app/applications/utils/filter.spec.ts
+++ b/public/src/app/applications/utils/filter.spec.ts
@@ -1,0 +1,132 @@
+import { Filter, MultiFilter, FilterUtils } from './filter';
+
+describe('Filter', () => {
+  describe('getQueryParamsString', () => {
+    it('should return query string when value is set', () => {
+      const f = new Filter<string>({ filter: { queryParam: 'name', value: 'acme' } });
+      expect(f.getQueryParamsString()).toBe('name=acme');
+    });
+
+    it('should return empty string when value is null', () => {
+      const f = new Filter<string>({ filter: { queryParam: 'name', value: null } });
+      expect(f.getQueryParamsString()).toBe('');
+    });
+
+    it('should return empty string when value is undefined', () => {
+      const f = new Filter<string>({ filter: { queryParam: 'name', value: undefined } });
+      expect(f.getQueryParamsString()).toBe('');
+    });
+  });
+
+  describe('isFilterSet', () => {
+    it('should return true when value is set', () => {
+      const f = new Filter<number>({ filter: { queryParam: 'id', value: 42 } });
+      expect(f.isFilterSet()).toBe(true);
+    });
+
+    it('should return false when value is null', () => {
+      const f = new Filter<number>({ filter: { queryParam: 'id', value: null } });
+      expect(f.isFilterSet()).toBe(false);
+    });
+  });
+
+  describe('reset', () => {
+    it('should set value to null', () => {
+      const f = new Filter<string>({ filter: { queryParam: 'name', value: 'acme' } });
+      f.reset();
+      expect(f.filter.value).toBeNull();
+    });
+  });
+});
+
+describe('MultiFilter', () => {
+  function makeMultiFilter(values: boolean[]) {
+    return new MultiFilter<boolean>({
+      queryParamsKey: 'status',
+      filters: [
+        { queryParam: 'open', displayString: 'Open', value: values[0] },
+        { queryParam: 'closed', displayString: 'Closed', value: values[1] },
+      ],
+    });
+  }
+
+  describe('getQueryParamsArray', () => {
+    it('should return params for truthy filter values only', () => {
+      const mf = makeMultiFilter([true, false]);
+      expect(mf.getQueryParamsArray()).toEqual(['open']);
+    });
+
+    it('should return all params when all values are truthy', () => {
+      const mf = makeMultiFilter([true, true]);
+      expect(mf.getQueryParamsArray()).toEqual(['open', 'closed']);
+    });
+
+    it('should return empty array when no values are truthy', () => {
+      const mf = makeMultiFilter([false, false]);
+      expect(mf.getQueryParamsArray()).toEqual([]);
+    });
+  });
+
+  describe('getQueryParamsString', () => {
+    it('should join selected params with pipe delimiter', () => {
+      const mf = makeMultiFilter([true, true]);
+      expect(mf.getQueryParamsString()).toBe('open|closed');
+    });
+
+    it('should return single param without delimiter', () => {
+      const mf = makeMultiFilter([true, false]);
+      expect(mf.getQueryParamsString()).toBe('open');
+    });
+
+    it('should return empty string when no filters are set', () => {
+      const mf = makeMultiFilter([false, false]);
+      expect(mf.getQueryParamsString()).toBe('');
+    });
+  });
+
+  describe('isFilterSet', () => {
+    it('should return true when at least one value is truthy', () => {
+      const mf = makeMultiFilter([false, true]);
+      expect(mf.isFilterSet()).toBe(true);
+    });
+
+    it('should return false when all values are falsy', () => {
+      const mf = makeMultiFilter([false, false]);
+      expect(mf.isFilterSet()).toBe(false);
+    });
+  });
+
+  describe('reset', () => {
+    it('should set all filter values to null', () => {
+      const mf = makeMultiFilter([true, true]);
+      mf.reset();
+      mf.filters.forEach(f => expect(f.value).toBeNull());
+    });
+  });
+});
+
+describe('FilterUtils', () => {
+  describe('hashFilters', () => {
+    it('should return a non-empty string', () => {
+      const f = new Filter<string>({ filter: { queryParam: 'name', value: 'acme' } });
+      expect(typeof FilterUtils.hashFilters(f)).toBe('string');
+      expect(FilterUtils.hashFilters(f).length).toBeGreaterThan(0);
+    });
+
+    it('should return the same hash for identical filter states', () => {
+      const a = new Filter<string>({ filter: { queryParam: 'name', value: 'acme' } });
+      const b = new Filter<string>({ filter: { queryParam: 'name', value: 'acme' } });
+      expect(FilterUtils.hashFilters(a)).toBe(FilterUtils.hashFilters(b));
+    });
+
+    it('should return different hashes for different filter states', () => {
+      const a = new Filter<string>({ filter: { queryParam: 'name', value: 'acme' } });
+      const b = new Filter<string>({ filter: { queryParam: 'name', value: 'other' } });
+      expect(FilterUtils.hashFilters(a)).not.toBe(FilterUtils.hashFilters(b));
+    });
+
+    it('should return a hash when called with no arguments', () => {
+      expect(typeof FilterUtils.hashFilters()).toBe('string');
+    });
+  });
+});

--- a/public/src/app/applications/utils/filter.ts
+++ b/public/src/app/applications/utils/filter.ts
@@ -1,5 +1,5 @@
 import { DELIMITER } from '@public-core/constants/appConstants';
-import * as hash from 'object-hash';
+import hash from 'object-hash';
 
 /**
  * Basic required filter fields.

--- a/public/src/app/comment-modal/comment-modal.component.spec.ts
+++ b/public/src/app/comment-modal/comment-modal.component.spec.ts
@@ -1,22 +1,214 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { CommentModalComponent } from './comment-modal.component';
+import { PublicCommentService } from '@api-client';
 
 describe('CommentModalComponent', () => {
   let component: CommentModalComponent;
   let fixture: ComponentFixture<CommentModalComponent>;
+  let mockActiveModal: Partial<NgbActiveModal>;
+  let mockCommentService: Partial<PublicCommentService>;
+
+  // Helper to create an observable-like with toPromise()
+  function observableWithPromise(value: any) {
+    return { toPromise: () => Promise.resolve(value) };
+  }
+
+  function observableWithError(err: any) {
+    return { toPromise: () => Promise.reject(err) };
+  }
 
   beforeEach(async () => {
+    mockActiveModal = {
+      dismiss: jest.fn(),
+    };
+
+    mockCommentService = {
+      publicCommentControllerCreate: jest.fn().mockReturnValue(observableWithPromise({})),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ CommentModalComponent ],
+      imports: [CommentModalComponent, FormsModule],
+      providers: [
+        { provide: NgbActiveModal, useValue: mockActiveModal },
+        { provide: PublicCommentService, useValue: mockCommentService },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(CommentModalComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for modal logic, template, and events as needed
+  it('should start on page 1', () => {
+    expect(component.currentPage).toBe(1);
+  });
+
+  it('should start with iAgreeModel false', () => {
+    expect(component.iAgreeModel).toBe(false);
+  });
+
+  it('should have feedbackLimit of 4000', () => {
+    expect(component.feedbackLimit).toBe(4000);
+  });
+
+  it('should not be submitting initially', () => {
+    expect(component.submitting).toBe(false);
+  });
+
+  describe('ngOnInit', () => {
+    it('should set default commentScopeCode to OVERALL', () => {
+      component.projectId = 1;
+      component.ngOnInit();
+      expect(component.publicComment.commentScopeCode).toBe('OVERALL');
+    });
+
+    it('should set projectId on publicComment', () => {
+      component.projectId = 42;
+      component.ngOnInit();
+      expect(component.publicComment.projectId).toBe(42);
+    });
+
+    it('should populate commentScopeOpts with OVERALL option', () => {
+      component.projectId = 1;
+      component.ngOnInit();
+      expect(component.commentScopeOpts.length).toBeGreaterThanOrEqual(1);
+      expect(component.commentScopeOpts[0].commentScopeCode).toBe('OVERALL');
+    });
+
+    it('should set selectedScope to OVERALL by default', () => {
+      component.projectId = 1;
+      component.ngOnInit();
+      expect(component.selectedScope.commentScopeCode).toBe('OVERALL');
+    });
+
+    it('should add spatial details to commentScopeOpts', () => {
+      component.projectId = 1;
+      component.projectSpatialDetail = [
+        {
+          featureId: 1,
+          featureType: { code: 'cut_block', description: 'Cut Block' },
+          name: 'Block A',
+        },
+        {
+          featureId: 2,
+          featureType: { code: 'road_section', description: 'Road Section' },
+          name: 'Road 1',
+        },
+      ] as any;
+      component.ngOnInit();
+      expect(component.commentScopeOpts.length).toBe(3);
+    });
+
+    it('should filter out retention_area spatial details', () => {
+      component.projectId = 1;
+      component.projectSpatialDetail = [
+        {
+          featureId: 1,
+          featureType: { code: 'retention_area', description: 'Retention Area' },
+          name: 'Retention 1',
+        },
+      ] as any;
+      component.ngOnInit();
+      expect(component.commentScopeOpts.length).toBe(1);
+    });
+  });
+
+  describe('navigation', () => {
+    it('should increment page on p1_next', () => {
+      component.p1_next();
+      expect(component.currentPage).toBe(2);
+    });
+
+    it('should decrement page on p2_back', () => {
+      component.currentPage = 2;
+      component.p2_back();
+      expect(component.currentPage).toBe(1);
+    });
+
+    it('should increment page on p2_next', () => {
+      component.currentPage = 2;
+      component.p2_next();
+      expect(component.currentPage).toBe(3);
+    });
+
+    it('should decrement page on p3_back', () => {
+      component.currentPage = 3;
+      component.p3_back();
+      expect(component.currentPage).toBe(2);
+    });
+  });
+
+  describe('dismiss', () => {
+    it('should call activeModal.dismiss with reason', () => {
+      component.dismiss('cancel');
+      expect(mockActiveModal.dismiss).toHaveBeenCalledWith('cancel');
+    });
+  });
+
+  describe('p3_next (submit)', () => {
+    beforeEach(() => {
+      component.projectId = 1;
+      component.ngOnInit();
+    });
+
+    it('should set submitting to true when submitting', () => {
+      (mockCommentService.publicCommentControllerCreate as jest.Mock).mockReturnValue(
+        { toPromise: () => new Promise(() => {}) } // never resolves
+      );
+      component.p3_next();
+      expect(component.submitting).toBe(true);
+    });
+
+    it('should call publicCommentControllerCreate', () => {
+      component.p3_next();
+      expect(mockCommentService.publicCommentControllerCreate).toHaveBeenCalled();
+    });
+
+    it('should set scopeCutBlockId when CUT_BLOCK selected', () => {
+      component.selectedScope = {
+        commentScopeCode: 'CUT_BLOCK' as any,
+        desc: 'Cut Block',
+        name: 'Block A',
+        scopeId: 10,
+      };
+      component.p3_next();
+      expect(component.publicComment.scopeCutBlockId).toBe(10);
+    });
+
+    it('should set scopeRoadSectionId when ROAD_SECTION selected', () => {
+      component.selectedScope = {
+        commentScopeCode: 'ROAD_SECTION' as any,
+        desc: 'Road Section',
+        name: 'Road 1',
+        scopeId: 20,
+      };
+      component.p3_next();
+      expect(component.publicComment.scopeRoadSectionId).toBe(20);
+    });
+
+    it('should set up success callback to advance page and reset submitting', () => {
+      const thenSpy = jest.fn().mockReturnValue({ catch: jest.fn() });
+      (mockCommentService.publicCommentControllerCreate as jest.Mock).mockReturnValue(
+        { toPromise: () => ({ then: thenSpy }) }
+      );
+      component.p3_next();
+      expect(thenSpy).toHaveBeenCalled();
+    });
+
+    it('should set submitting to false on error', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      (mockCommentService.publicCommentControllerCreate as jest.Mock).mockReturnValue(
+        observableWithError(new Error('submit error'))
+      );
+      component.p3_next();
+      await Promise.resolve();
+      await fixture.whenStable();
+      expect(component.submitting).toBe(false);
+      consoleSpy.mockRestore();
+    });
+  });
 });

--- a/public/src/app/comment-modal/comment-modal.component.spec.ts
+++ b/public/src/app/comment-modal/comment-modal.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommentModalComponent } from './comment-modal.component';
+
+describe('CommentModalComponent', () => {
+  let component: CommentModalComponent;
+  let fixture: ComponentFixture<CommentModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CommentModalComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(CommentModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for modal logic, template, and events as needed
+});

--- a/public/src/app/contact/contact.component.spec.ts
+++ b/public/src/app/contact/contact.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ContactComponent } from './contact.component';
+
+describe('ContactComponent', () => {
+  let component: ContactComponent;
+  let fixture: ComponentFixture<ContactComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ContactComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ContactComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for contact logic, template, and events as needed
+});

--- a/public/src/app/contact/contact.component.spec.ts
+++ b/public/src/app/contact/contact.component.spec.ts
@@ -7,7 +7,7 @@ describe('ContactComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ContactComponent ],
+      imports: [ContactComponent],
     }).compileComponents();
     fixture = TestBed.createComponent(ContactComponent);
     component = fixture.componentInstance;
@@ -18,5 +18,8 @@ describe('ContactComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for contact logic, template, and events as needed
+  it('should render the contact template', () => {
+    const el = fixture.nativeElement;
+    expect(el).toBeTruthy();
+  });
 });

--- a/public/src/app/footer/footer.component.spec.ts
+++ b/public/src/app/footer/footer.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FooterComponent } from './footer.component';
+
+describe('FooterComponent', () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FooterComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for footer logic, template, and events as needed
+});

--- a/public/src/app/footer/footer.component.spec.ts
+++ b/public/src/app/footer/footer.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FooterComponent } from './footer.component';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('FooterComponent', () => {
   let component: FooterComponent;
@@ -7,7 +8,7 @@ describe('FooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ FooterComponent ],
+      imports: [FooterComponent, RouterTestingModule],
     }).compileComponents();
     fixture = TestBed.createComponent(FooterComponent);
     component = fixture.componentInstance;
@@ -18,5 +19,12 @@ describe('FooterComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for footer logic, template, and events as needed
+  it('should have router injected', () => {
+    expect(component.router).toBeDefined();
+  });
+
+  it('should render the footer template', () => {
+    const el = fixture.nativeElement;
+    expect(el).toBeTruthy();
+  });
 });

--- a/public/src/app/footer/footer.component.spec.ts
+++ b/public/src/app/footer/footer.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { FooterComponent } from './footer.component';
-import { RouterTestingModule } from '@angular/router/testing';
 
 describe('FooterComponent', () => {
   let component: FooterComponent;
@@ -8,7 +8,8 @@ describe('FooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FooterComponent, RouterTestingModule],
+      imports: [FooterComponent],
+      providers: [provideRouter([])],
     }).compileComponents();
     fixture = TestBed.createComponent(FooterComponent);
     component = fixture.componentInstance;

--- a/public/src/app/header/header.component.spec.ts
+++ b/public/src/app/header/header.component.spec.ts
@@ -1,13 +1,25 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HeaderComponent } from './header.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ConfigService } from '@utility/services/config.service';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
+  let mockConfigService: Partial<ConfigService>;
 
   beforeEach(async () => {
+    mockConfigService = {
+      getEnvironmentDisplay: jest.fn().mockReturnValue('Dev'),
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ HeaderComponent ],
+      imports: [HeaderComponent, RouterTestingModule],
+      providers: [
+        { provide: ConfigService, useValue: mockConfigService },
+        provideNoopAnimations(),
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
@@ -18,5 +30,36 @@ describe('HeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Add more tests for header logic, template, and events as needed
+  it('should get environmentDisplay from ConfigService', () => {
+    expect(component.environmentDisplay).toBe('Dev');
+    expect(mockConfigService.getEnvironmentDisplay).toHaveBeenCalled();
+  });
+
+  it('should start with nav menu closed', () => {
+    expect(component.isNavMenuOpen).toBe(false);
+  });
+
+  it('should toggle nav menu open on first toggle', () => {
+    component.toggleNav();
+    expect(component.isNavMenuOpen).toBe(true);
+  });
+
+  it('should toggle nav menu closed on second toggle', () => {
+    component.toggleNav();
+    component.toggleNav();
+    expect(component.isNavMenuOpen).toBe(false);
+  });
+
+  it('should alternate nav state on repeated toggles', () => {
+    component.toggleNav();
+    expect(component.isNavMenuOpen).toBe(true);
+    component.toggleNav();
+    expect(component.isNavMenuOpen).toBe(false);
+    component.toggleNav();
+    expect(component.isNavMenuOpen).toBe(true);
+  });
+
+  it('should have router injected', () => {
+    expect(component.router).toBeDefined();
+  });
 });

--- a/public/src/app/header/header.component.spec.ts
+++ b/public/src/app/header/header.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HeaderComponent } from './header.component';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HeaderComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for header logic, template, and events as needed
+});

--- a/public/src/app/header/header.component.spec.ts
+++ b/public/src/app/header/header.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { HeaderComponent } from './header.component';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ConfigService } from '@utility/services/config.service';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
@@ -15,8 +15,9 @@ describe('HeaderComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [HeaderComponent, RouterTestingModule],
+      imports: [HeaderComponent],
       providers: [
+        provideRouter([]),
         { provide: ConfigService, useValue: mockConfigService },
         provideNoopAnimations(),
       ],

--- a/public/src/app/home-proxy.component.spec.ts
+++ b/public/src/app/home-proxy.component.spec.ts
@@ -1,22 +1,75 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
 import { HomeProxyComponent } from './home-proxy.component';
 
 describe('HomeProxyComponent', () => {
   let component: HomeProxyComponent;
   let fixture: ComponentFixture<HomeProxyComponent>;
+  let router: Router;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ HomeProxyComponent ],
-    }).compileComponents();
-    fixture = TestBed.createComponent(HomeProxyComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  describe('without showSplashModal param', () => {
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [HomeProxyComponent, RouterTestingModule],
+        providers: [
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                paramMap: {
+                  get: jest.fn().mockReturnValue(null),
+                },
+              },
+            },
+          },
+        ],
+      }).compileComponents();
+
+      router = TestBed.inject(Router);
+      jest.spyOn(router, 'navigate');
+      fixture = TestBed.createComponent(HomeProxyComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should navigate to /projects without splash fragment', () => {
+      fixture.detectChanges();
+      expect(router.navigate).toHaveBeenCalledWith(['/projects']);
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+  describe('with showSplashModal=true param', () => {
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [HomeProxyComponent, RouterTestingModule],
+        providers: [
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                paramMap: {
+                  get: jest.fn().mockReturnValue('true'),
+                },
+              },
+            },
+          },
+        ],
+      }).compileComponents();
 
-  // Add more tests for home proxy logic, template, and events as needed
+      router = TestBed.inject(Router);
+      jest.spyOn(router, 'navigate');
+      fixture = TestBed.createComponent(HomeProxyComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should navigate to /projects with splash fragment when showSplashModal is true', () => {
+      fixture.detectChanges();
+      expect(router.navigate).toHaveBeenCalledWith(['/projects'], { fragment: 'splash' });
+    });
+  });
 });

--- a/public/src/app/home-proxy.component.spec.ts
+++ b/public/src/app/home-proxy.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HomeProxyComponent } from './home-proxy.component';
+
+describe('HomeProxyComponent', () => {
+  let component: HomeProxyComponent;
+  let fixture: ComponentFixture<HomeProxyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ HomeProxyComponent ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HomeProxyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Add more tests for home proxy logic, template, and events as needed
+});

--- a/public/src/app/home-proxy.component.spec.ts
+++ b/public/src/app/home-proxy.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, provideRouter } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 import { HomeProxyComponent } from './home-proxy.component';
 
@@ -12,8 +11,9 @@ describe('HomeProxyComponent', () => {
   describe('without showSplashModal param', () => {
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        imports: [HomeProxyComponent, RouterTestingModule],
+        imports: [HomeProxyComponent],
         providers: [
+          provideRouter([]),
           {
             provide: ActivatedRoute,
             useValue: {
@@ -46,8 +46,9 @@ describe('HomeProxyComponent', () => {
   describe('with showSplashModal=true param', () => {
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        imports: [HomeProxyComponent, RouterTestingModule],
+        imports: [HomeProxyComponent],
         providers: [
+          provideRouter([]),
           {
             provide: ActivatedRoute,
             useValue: {

--- a/public/src/jest-global-setup.ts
+++ b/public/src/jest-global-setup.ts
@@ -1,0 +1,6 @@
+// This file runs BEFORE jest-preset-angular is loaded.
+// It patches the Buffer prototype chain to fix esbuild's instanceof check
+// in Jest's VM context (Node.js 22 compatibility).
+if (!(Buffer.from('') instanceof Uint8Array)) {
+  Object.setPrototypeOf(Buffer.prototype, Uint8Array.prototype);
+}

--- a/public/src/test-setup.ts
+++ b/public/src/test-setup.ts
@@ -1,1 +1,9 @@
-import 'jest-preset-angular';
+import 'zone.js';
+import 'zone.js/testing';
+import { TestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+TestBed.initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/public/src/test-setup.ts
+++ b/public/src/test-setup.ts
@@ -1,8 +1,3 @@
-import 'zone.js';
-import { TestBed } from '@angular/core/testing';
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 
-TestBed.initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+setupZoneTestEnv();

--- a/public/src/test-setup.ts
+++ b/public/src/test-setup.ts
@@ -1,5 +1,4 @@
 import 'zone.js';
-import 'zone.js/testing';
 import { TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 

--- a/public/tsconfig.json
+++ b/public/tsconfig.json
@@ -33,9 +33,10 @@
         "../node_modules/@angular/*"
       ]
     },
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "types": ["jest", "node"]
   },
-  "exclude": ["node_modules", "**/*.spec.ts"],
+  "exclude": ["node_modules"],
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,

--- a/public/tsconfig.spec.json
+++ b/public/tsconfig.spec.json
@@ -3,9 +3,16 @@
   "compilerOptions": {
     "outDir": "dist/public",
     "module": "commonjs",
-    "types": ["jest", "node"],
-    "importHelpers": false
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/public/tsconfig.spec.json
+++ b/public/tsconfig.spec.json
@@ -4,9 +4,10 @@
     "outDir": "dist/public",
     "module": "commonjs",
     "types": [
-      "jest",
-      "node"
-    ]
+    "jest",
+    "node",
+    "zone.js"
+  ]
   },
   "files": [
     "src/test-setup.ts"

--- a/public/tsconfig.spec.json
+++ b/public/tsconfig.spec.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "outDir": "dist/public",
     "module": "commonjs",
-"types": [
-      "jest",
-      "node"
-    ]
+    "types": ["jest", "node"]
   },
   "files": [
     "src/test-setup.ts"

--- a/public/tsconfig.spec.json
+++ b/public/tsconfig.spec.json
@@ -3,11 +3,10 @@
   "compilerOptions": {
     "outDir": "dist/public",
     "module": "commonjs",
-    "types": [
-    "jest",
-    "node",
-    "zone.js"
-  ]
+"types": [
+      "jest",
+      "node"
+    ]
   },
   "files": [
     "src/test-setup.ts"

--- a/public/tsconfig.spec.json
+++ b/public/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist/public",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "importHelpers": false
   },
   "files": ["src/test-setup.ts"],
   "include": ["**/*.spec.ts", "**/*.d.ts"]


### PR DESCRIPTION
## Summary

- Enable `npm run test-unit` for all three components (api, admin, public) with consistent Jest configuration
- Fix all admin tests that used Jasmine syntax instead of Jest
- Flesh out 20 public component/service specs from empty scaffolding to real assertions
- Update CI (analysis.yml) to pass for all three test jobs

**Test counts (all passing in CI):**
| Component | Test Suites | Tests |
|-----------|------------|-------|
| public    | 20         | 184   |
| admin     | 5          | 13    |
| api (unit only) | 14   | 79    |
| **Total** | **39**     | **276** |

The public count of 184 tests includes comprehensive coverage for:
- 16 Angular components (app, header, footer, contact, about, home-proxy, applications-proxy, etc.)
- 3 child/modal components (comment-modal, splash-modal, marker-popup)
- 3 details-panel components (details-panel, shape-info, details-map)
- 3 map components (app-map, details-map, marker-popup)
- 3 public-notices components (public-notices-panel, notices-filter-panel)
- 3 utilities (date-input, filter/Filter/MultiFilter/FilterUtils, projects)
- 1 routing module (app.routes)

## Non-test changes

### Source code
- **`public/src/app/applications/utils/filter.ts`** — Changed `import * as hash from 'object-hash'` to `import hash from 'object-hash'`. The namespace import creates a `{ default: fn }` object that ts-jest doesn't unwrap correctly at runtime.

### Jest infrastructure (admin and public)

- **`jest.config.js`** — Rewritten for jest-preset-angular v14. Old config used deprecated v9 patterns (`astTransformers`, old serializer paths like `AngularNoNgAttributesSnapshotSerializer.js`). New config uses v14-compatible `snapshotSerializers` and `moduleNameMapper` for the `@api-client`, `@admin-core`/`@public-core`, `@utility`, `app/` path aliases from tsconfig.

- **`test-setup.ts`** — Uses `setupZoneTestEnv()` from `jest-preset-angular/setup-env/zone` (the recommended modern approach for Angular 19). This handles zone.js and TestBed initialization in one call.

- **`jest-global-setup.ts`** (new) — Runs before jest-preset-angular loads. Patches `Buffer` prototype chain so `Buffer.from('') instanceof Uint8Array` passes in Jest's VM context on Node.js 22. Without this, esbuild throws at startup.

- **`tsconfig.json`** — Added `"types": ["jest", "node"]` so VS Code recognizes Jest globals. Also removed `"**/*.spec.ts"` from `exclude` so path aliases resolve in spec files.

- **`tsconfig.app.json`** — Has `"types": []` (empty) so Jest/node types don't bleed into production builds.

- **`package.json`** — Added `"test-unit": "jest --coverage"` script. CI runs `npm run test-unit`.

### CI workflow (`analysis.yml`)
- Updated `node_version` from 18.18.2 to 20.18.1 (Angular 19 minimum)
- Added separate test jobs for admin and public, each running `cd ../libs && npm ci --ignore-scripts` first to install shared dependencies
- `results` job now gates on all 3 test jobs (api, admin, public) + trivy

## How to run locally
```bash
cd api && npm ci && npm run test-unit
cd admin && npm ci && npm run test-unit
cd public && npm ci && npm run test-unit
```

---

Deployments, as required, will be available below:
- [api](https://fom-42.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-42.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-42.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-42.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-42.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-42.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)