### PR TITLE
fix: #926 Spatial Upload Empty Object Issue

### DIFF
--- a/admin/src/app/foms/fom-submission/fom-submission.component.ts
+++ b/admin/src/app/foms/fom-submission/fom-submission.component.ts
@@ -157,18 +157,39 @@ export class FomSubmissionComponent implements OnInit, AfterViewInit, OnDestroy 
 
   onFileEmit(newFile: File) {
     this.file = newFile;
-    try {
-      if (this.file) {
-        const reader = new FileReader();
-        reader.onload = (e: any) => {
-          this.originalSubmissionRequest.jsonSpatialSubmission = JSON.parse(e.target.result);
-        };
-        reader.readAsText(this.file);
-      }
-    }catch (e) {
-      this.modalSvc.openErrorDialog('The file is not in a valid JSON format. Please fix your file and try again.');
+    if (!this.file) {
+      this.modalSvc.openErrorDialog('Please select a JSON file to continue.');
+      return;
     }
-    this.fg.get('jsonSpatialSubmission').setValue(this.originalSubmissionRequest.jsonSpatialSubmission);
+
+    try {
+      const reader = new FileReader();
+      reader.onload = (e: ProgressEvent<FileReader>) => {
+        if (reader.readyState !== FileReader.DONE) {
+          return;
+        }
+
+        try {
+          const content = e.target?.result;
+          if (typeof content !== 'string') {
+            throw new Error('File content is not text.');
+          }
+
+          this.originalSubmissionRequest.jsonSpatialSubmission = JSON.parse(content);
+          this.fg.get('jsonSpatialSubmission').setValue(this.originalSubmissionRequest.jsonSpatialSubmission);
+        } catch (_parseError) {
+          this.modalSvc.openErrorDialog('The selected file is not valid JSON. Please fix the file and try again.');
+        }
+      };
+
+      reader.onerror = () => {
+        this.modalSvc.openErrorDialog('Could not read the selected file. Please try again.');
+      };
+
+      reader.readAsText(this.file);
+    } catch (_readSetupError) {
+      this.modalSvc.openErrorDialog('Could not process the selected file. Please try again.');
+    }
   }
 
   submit() {


### PR DESCRIPTION
ref: #926 
Fixes an issue where uploading a correct/valid spatial file resulting confusing error popup for message stating containing empty submission.
- Refactor onFileEmit for better error handling.
- Use `reader.readyState` to determine when to be ready to parse content for submitting.
- Move previously setting form property too early into proper place because FileReader is async.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-28.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-28.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-28.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)