### PR TITLE
fix(compose): compose config and image updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         cd ../admin && npm ci --ignore-scripts &&
         npm run start:admin
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4200/admin"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:4200/admin', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 10s
       retries: 3
       start_period: 60s
@@ -51,7 +51,7 @@ services:
       - OBJECT_STORAGE_URL=nrs.objectstore.gov.bc.ca
       - OBJECT_STORAGE_ACCESS_ID=nr-fom-dev
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3333/api"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3333/api', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 10s
       retries: 3
       start_period: 60s
@@ -104,7 +104,7 @@ services:
         cd ../public && npm ci --ignore-scripts &&
         npm run start:public
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4300/public"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:4300/public', r => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 10s
       retries: 3
       start_period: 60s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 volumes:
   postgres-data:
 
@@ -22,7 +20,7 @@ services:
       retries: 3
       start_period: 60s
       timeout: 5s
-    image: node:18
+    image: node:20.19.0-alpine3.20
     ports:
       - 4200:4200
     volumes:
@@ -58,11 +56,9 @@ services:
       retries: 3
       start_period: 60s
       timeout: 5s
-    image: node:18 # need update to node 20
+    image: node:20.19.0-alpine3.20
     ports:
       - 3333:3333
-    links:
-      - db:database
     volumes:
       - .:/app:z
     working_dir: /app
@@ -113,7 +109,7 @@ services:
       retries: 3
       start_period: 60s
       timeout: 5s
-    image: node:18
+    image: node:20.19.0-alpine3.20
     ports:
       - 4300:4300
     volumes:


### PR DESCRIPTION
## Summary

Fixes `podman compose up` failing with two errors:

- **`link is not supported`** — removed deprecated `links: db:database` from the `api` service; `depends_on` + the shared default network is sufficient
- **`version` warning** — removed obsolete `version: '3.8'` field
- **Node 18 → 20.19.0-alpine3.20** — Node 18 is EOL and Angular CLI 21 requires `>=20.19`; bumped all three frontend/backend services

No functional changes to service wiring or environment configuration.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-32.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-32.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-32.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)