### PR TITLE
fix: #878 Improve Chart Plot for Comments by District

### DIFF
--- a/admin/src/app/analytics-dashboard/analytics-dashboard-chart-config.ts
+++ b/admin/src/app/analytics-dashboard/analytics-dashboard-chart-config.ts
@@ -1,4 +1,4 @@
-import { ApexAxisChartSeries, ApexChart, ApexDataLabels, ApexFill, ApexGrid, ApexLegend, ApexPlotOptions, ApexTheme, ApexTitleSubtitle, ApexXAxis, ApexYAxis, ChartType } from 'ng-apexcharts';
+import { ApexAxisChartSeries, ApexChart, ApexDataLabels, ApexFill, ApexGrid, ApexLegend, ApexPlotOptions, ApexStroke, ApexTheme, ApexTitleSubtitle, ApexXAxis, ApexYAxis, ChartType } from 'ng-apexcharts';
 
 export type ChartOptions = {
   series: ApexAxisChartSeries;
@@ -12,6 +12,8 @@ export type ChartOptions = {
   theme: ApexTheme;
   grid: ApexGrid;
   legend: ApexLegend;
+  stroke?: ApexStroke;
+  tooltip?: ApexTooltip;
 };
 
 const COLOR_LABEL = "#304758";
@@ -243,7 +245,8 @@ export const commentsByDistrictChartOptions = {
     enabled: true,
     position: 'right',
     formatter: function(val: number) {
-      return '\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0' + val;
+      //'offsetX' does not work well so using non-breaking spaces \u00A0 for manual offset for label position.
+      return val === 0 ? '' : '\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0' + val; 
     },
     style: {
       fontSize: "12px",
@@ -286,6 +289,23 @@ export const commentsByDistrictChartOptions = {
     show: true,
     position: 'top' as const,
     horizontalAlign: 'left' as const,
+    // use custom legends with markers for all categories than default to prevent missing legends when some categories have 0 comments in all districts.
+    customLegendItems: [
+      'Considered',
+      'Addressed',
+      'Not Applicable',
+      'Not Categorized',
+      'Total'
+    ],
+    markers: {
+      fillColors: [
+        RESPONSE_CODE_COLORS['CONSIDERED'],
+        RESPONSE_CODE_COLORS['ADDRESSED'],
+        RESPONSE_CODE_COLORS['IRRELEVANT'],
+        RESPONSE_CODE_COLORS['NOT_CATEGORIZED'],
+        RESPONSE_CODE_COLORS['TOTAL']
+      ]
+    }
   }
 };
 

--- a/admin/src/app/analytics-dashboard/analytics-dashboard.component.ts
+++ b/admin/src/app/analytics-dashboard/analytics-dashboard.component.ts
@@ -7,7 +7,11 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { ActivatedRoute } from '@angular/router';
 import { ProjectPlanCodeFilterEnum, ResponseCodeEnum } from '@api-client';
-import { ChartOptions, commentsByDistrictChartOptions, commentsByResponseCodeChartOptions, fomsCountByDistrictChartOptions, fomsCountByForestClientChartOptions, maxAxis, maxAxis as maxxAxis, RESPONSE_CODE_COLORS, RESPONSE_CODE_LABELS, topCommentedProjectsChartOptions } from 'app/analytics-dashboard/analytics-dashboard-chart-config';
+import {
+  ChartOptions, commentsByDistrictChartOptions, commentsByResponseCodeChartOptions, fomsCountByDistrictChartOptions,
+  fomsCountByForestClientChartOptions, maxAxis, maxAxis as maxxAxis, RESPONSE_CODE_COLORS, RESPONSE_CODE_LABELS,
+  topCommentedProjectsChartOptions
+} from 'app/analytics-dashboard/analytics-dashboard-chart-config';
 import { AnalyticsDashboardData, AnalyticsDashboardDataService, ApiError } from 'app/analytics-dashboard/analytics-dashboard-data.service';
 import { DateTime } from 'luxon';
 import {
@@ -227,9 +231,10 @@ export class AnalyticsDashboardComponent implements OnInit, AfterViewInit {
   }
 
   applyCommentsByDistrictChartOptions() {
+    // apiData example: [{"districtId":43,"districtName":"Campbell River","totalPublicCommentCount":1110,"commentCountByCategory":[{"responseCode":"NOT_CATEGORIZED","publicCommentCount":19},{"responseCode":"CONSIDERED","publicCommentCount":1},{"responseCode":"IRRELEVANT","publicCommentCount":0},{"responseCode":"ADDRESSED","publicCommentCount":0}]}]
     const apiData = this.analyticsData().commentCountByDistrict;
     if (apiData && !(apiData instanceof ApiError)) {
-      // Update district filter options
+      // Update district select filter options
       this.districtFilterOptions = [
         { value: null, label: 'All districts' },
         ...apiData.map(item => ({ value: item.districtId, label: item.districtName }))
@@ -261,10 +266,10 @@ export class AnalyticsDashboardComponent implements OnInit, AfterViewInit {
           return category ? category.publicCommentCount : 0;
         });
         series.push({
-          name: RESPONSE_CODE_LABELS[responseCode] || responseCode,
+          name: RESPONSE_CODE_LABELS[responseCode as keyof typeof RESPONSE_CODE_LABELS] || responseCode,
           data: data
         });
-        seriesColors.push(RESPONSE_CODE_COLORS[responseCode] || '#999999');
+        seriesColors.push(RESPONSE_CODE_COLORS[responseCode as keyof typeof RESPONSE_CODE_COLORS] || '#999999');
       });
 
       // Add Total series
@@ -290,6 +295,11 @@ export class AnalyticsDashboardComponent implements OnInit, AfterViewInit {
         colors: seriesColors,
         chart: {
           height: Math.max(300, filteredData.length * 80)
+        },
+        stroke: {
+          show: true,
+          width: 1,
+          colors: ['#fff']
         }
       });
     }

--- a/api/src/app/modules/public-comment/public-comment.service.ts
+++ b/api/src/app/modules/public-comment/public-comment.service.ts
@@ -19,6 +19,7 @@ import {
     PublicCommentCreateRequest,
 } from './public-comment.dto';
 import { PublicComment } from './public-comment.entity';
+import { ResponseCodeEnum } from './response-code.entity';
 
 @Injectable()
 export class PublicCommentService extends DataService<
@@ -281,6 +282,23 @@ export class PublicCommentService extends DataService<
         publicCommentCount: Number(row.publicCommentCount),
       });
       district.totalPublicCommentCount += Number(row.publicCommentCount);
+    });
+
+    // Ensure that for each district, we have a count for every response code, even if has no comment on that response code.
+    const allResponseCodes = [
+      ...Object.values(ResponseCodeEnum),
+      'NOT_CATEGORIZED'
+    ];
+    districtMap.forEach(district => {
+      allResponseCodes.forEach(code => {
+        if (!district.commentCountByCategory.some(c => c.responseCode === code)) {
+          // If a response code has no comments for this district, add it with count 0
+          district.commentCountByCategory.push({
+            responseCode: code,
+            publicCommentCount: 0,
+          });
+        }
+      });
     });
 
     return Array.from(districtMap.values());


### PR DESCRIPTION
ref: #878 
Improve Comments by Districts and Categories chart.
- Remove strange labeling '0' when no counts on certain categories.
- Make gap between category bars
- Show all legends regardless 0 count on some categories.

<img width="1693" height="537" alt="image" src="https://github.com/user-attachments/assets/924a9a00-48cd-457e-9acd-f57a9a7a26c4" />

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-34.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-34.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-34.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)