### PR TITLE
chore(ci): id-token and attestations write permissions for builds

### DIFF
--- a/.github/workflows/db-major-upgrade.yml
+++ b/.github/workflows/db-major-upgrade.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
     - name: Checkout

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       packages: write
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         package: [admin, api, db, public]

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       packages: write
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         package: [admin, api, db, public]


### PR DESCRIPTION
GitHub Actions workflows need id-token: write and attestations: write permissions to perform attestation of builds.

Closes #955

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-6.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-6.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-6.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)