### PR TITLE
ci(workflows): skip smoke tests if deployment is not triggered

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -56,6 +56,9 @@ on:
       url:
         description: URL for deployment
         value: ${{ jobs.init.outputs.url }}
+      triggered:
+        description: Did a deployment trigger?
+        value: ${{ jobs.init.outputs.triggered }}
 
 permissions: {}
 
@@ -66,6 +69,7 @@ jobs:
     outputs:
       tag: ${{ steps.vars.outputs.tag }}
       url: ${{ steps.vars.outputs.url }}
+      triggered: ${{ steps.openshift-init.outputs.triggered }}
     runs-on: ubuntu-24.04
     steps:
       # Get PR number - requires squash merges to main
@@ -103,6 +107,7 @@ jobs:
           fi
 
       - name: OpenShift Init
+        id: openshift-init
         uses: bcgov/action-deployer-openshift@v4.1.0
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -59,6 +59,7 @@ jobs:
   smoke:
     name: Smoke Test
     needs: [deploy]
+    if: needs.deploy.outputs.triggered == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Wait for App to respond


### PR DESCRIPTION
Skip smoke tests when no deployment occurred by checking the triggered output from OpenShift Init.

Closes #957

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-8.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-8.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-8.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)