### PR TITLE
fix: #2169 Resolved form biding ordering that causes bug.

### DIFF
--- a/admin/src/app/foms/review-comments/review-comments.component.html
+++ b/admin/src/app/foms/review-comments/review-comments.component.html
@@ -72,9 +72,9 @@
         <div class="review-comments__detail panel" *ngIf="selectedItem as activeComment; else noCommentSelected">
           <div class="panel-scroll">
             <app-comment-detail #commentDetailForm="commentForm"
-                [selectedComment]="activeComment"
                 [responseCodes]="responseCodes"
-                [canReplyComment]="canReplyComment()">
+                [canReplyComment]="canReplyComment()"
+                [selectedComment]="activeComment">
               <div class="row">
                 <button type="button" title="Save this comment response"
                         class="btn btn-sm btn-primary btn-container"


### PR DESCRIPTION
ref: #2169
- Fix behavior bug (only happens on first item click) for form binding ordering.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-47.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-47.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-47.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)