### PR TITLE
feat(ops): automate TLS certificate injection for prod

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -158,3 +158,19 @@ jobs:
             ${{ matrix.name != 'db' && format('-p REPLICA_COUNT={0}', inputs.replica_count) || '' }}
             ${{ matrix.parameters }}
           triggers: ${{ inputs.triggers }}
+
+      - name: Inject TLS Certificates (Prod Only)
+        if: ${{ inputs.target == 'prod' && matrix.name == 'public' }}
+        uses: bcgov/action-deployer-openshift@v4.2.0
+        with:
+          file: public/openshift.tls.yml
+          oc_namespace: ${{ vars.OC_NAMESPACE }}
+          oc_server: ${{ vars.OC_SERVER }}
+          oc_token: ${{ secrets.OC_TOKEN }}
+          overwrite: true
+          parameters:
+            -p ZONE=${{ inputs.target }}
+            -p URL=${{ needs.init.outputs.url }}
+            -p TLS_CERTIFICATE="${{ secrets.PROD_TLS_CERTIFICATE }}"
+            -p TLS_PRIVATE_KEY="${{ secrets.PROD_TLS_PRIVATE_KEY }}"
+            -p TLS_CA_CERTIFICATE="${{ secrets.PROD_TLS_CA_CERTIFICATE }}"

--- a/public/openshift.tls.yml
+++ b/public/openshift.tls.yml
@@ -1,0 +1,43 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: fom-tls
+  annotations:
+    description: "Injects TLS certificates into the master route"
+parameters:
+  - name: NAME
+    value: fom
+  - name: ZONE
+    required: true
+  - name: COMPONENT
+    value: public
+  - name: URL
+    required: true
+  - name: TLS_CERTIFICATE
+    required: true
+  - name: TLS_PRIVATE_KEY
+    required: true
+  - name: TLS_CA_CERTIFICATE
+    required: true
+objects:
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}-root
+    spec:
+      host: ${URL}
+      path: /
+      port:
+        targetPort: 4300-tcp
+      to:
+        kind: Service
+        name: ${NAME}-${ZONE}-${COMPONENT}
+        weight: 100
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+        certificate: "${TLS_CERTIFICATE}"
+        key: "${TLS_PRIVATE_KEY}"
+        caCertificate: "${TLS_CA_CERTIFICATE}"


### PR DESCRIPTION
This PR permanently moves TLS certificate management out of the OpenShift Web Console and strictly into Infrastructure as Code via GitHub Actions.

### Changes
*   Creates `public/openshift.tls.yml` to act as the master TLS route template.
*   Modifies `.github/workflows/.deploy.yml` to inject GitHub Secrets into the deployment pipeline when `target == prod`.

### Required Actions Before Merge
A repository administrator MUST create the following Repository Secrets in GitHub before this pipeline is run:
*   `PROD_TLS_CERTIFICATE`
*   `PROD_TLS_PRIVATE_KEY`
*   `PROD_TLS_CA_CERTIFICATE`

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-36.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-36.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-36.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)