### PR TITLE
chore(ci): codeowners, workflow-notifier for deployer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DerekRoberts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
-* @DerekRoberts
+# Matched against repo root (asterisk)
+*                         @arcshiftsolutions @OlgaLiber2 @DerekRoberts
+
+# Matched against directories
+# /.github/workflows/       TBD
+
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -173,6 +173,6 @@ jobs:
         uses: bcgov/actions/workflow-notifier@v0.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Deployment Failure: FOM (${{ inputs.environment || inputs.target || 'unknown' }})"
+          title: "Deployment Failure: FOM (${{ inputs.target }})"
           labels: "bug,failure,deployment"
 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -158,3 +158,21 @@ jobs:
             ${{ matrix.name != 'db' && format('-p REPLICA_COUNT={0}', inputs.replica_count) || '' }}
             ${{ matrix.parameters }}
           triggers: ${{ inputs.triggers }}
+
+  notify:
+    name: Notify Failure
+    needs: [init, deploy]
+    if: always() && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Notify Owners on Failure
+        uses: bcgov/actions/workflow-notifier@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Deployment Failure: FOM (${{ inputs.environment || inputs.target || 'unknown' }})"
+          labels: "bug,failure,deployment"
+

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -162,7 +162,7 @@ jobs:
   notify:
     name: Notify Failure
     needs: [init, deploy]
-    if: always() && contains(needs.*.result, 'failure')
+    if: always() && contains(needs.*.result, 'failure') && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -128,21 +128,4 @@ jobs:
 
       - name: Success Message
         run: echo "✅ All critical checks passed or were intentionally skipped!"
-
-  notify:
-    name: Notify Failure
-    needs: [tests-admin, tests-api, tests-public, trivy]
-    if: always() && contains(needs.*.result, 'failure') && (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - uses: actions/checkout@v7
-      - name: Notify Owners on Failure
-        uses: bcgov/actions/workflow-notifier@v0.5.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          title: "Analysis Failure: FOM (${{ github.event_name }})"
-          labels: "bug,failure,analysis"
-
+        

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -128,3 +128,21 @@ jobs:
 
       - name: Success Message
         run: echo "✅ All critical checks passed or were intentionally skipped!"
+
+  notify:
+    name: Notify Failure
+    needs: [tests-admin, tests-api, tests-public, trivy]
+    if: always() && contains(needs.*.result, 'failure') && (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Notify Owners on Failure
+        uses: bcgov/actions/workflow-notifier@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Analysis Failure: FOM (${{ github.event_name }})"
+          labels: "bug,failure,analysis"
+

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -17,6 +17,9 @@ permissions: {}
 jobs:
   deploy:
     name: Deploy (TEST)
+    permissions:
+      contents: read
+      issues: write
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -52,7 +52,6 @@ jobs:
     needs: [build]
     permissions:
       contents: read
-      issues: write
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -52,6 +52,7 @@ jobs:
     needs: [build]
     permissions:
       contents: read
+      issues: write
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -50,6 +50,9 @@ jobs:
   deploy:
     name: Deploy (${{ github.event.number }})
     needs: [build]
+    permissions:
+      contents: read
+      issues: write
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -18,6 +18,9 @@ permissions: {}
 jobs:
   deploy:
     name: Deploy (PROD)
+    permissions:
+      contents: read
+      issues: write
     secrets: inherit
     uses: ./.github/workflows/.deploy.yml
     with:


### PR DESCRIPTION
## Description

Closes #217

Integrates `bcgov/actions/workflow-notifier@v0.5.0` into GitHub Actions workflows to automatically notify code owners via GitHub Issues whenever workflow failures occur.

This sets up the pattern.  If we're going to use this with cronjobs or anything else they need to be orchestrated in GitHub Actions.  There are some cronjobs, but I'm not aware of the situation.  Feel free to make suggestions or requets.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [api](https://fom-40.apps.silver.devops.gov.bc.ca/api)
- [admin](https://fom-40.apps.silver.devops.gov.bc.ca/admin)
- [public](https://fom-40.apps.silver.devops.gov.bc.ca/public)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fom/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fom/actions/workflows/merge.yml)